### PR TITLE
WIP: (PDB-1488) Connection pooling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ks-version "1.0.0")
+(def ks-version "1.1.0")
 
 (defproject puppetlabs/jdbc-util "0.1.1-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
@@ -7,11 +7,20 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/java.jdbc "0.3.2"]
-                 [org.postgresql/postgresql "9.3-1100-jdbc41"]
-                 [com.jolbox/bonecp "0.8.0.RELEASE" :exclusions [[org.slf4j/slf4j-api]]]
+  :dependencies [[com.jolbox/bonecp "0.8.0.RELEASE" :exclusions [[org.slf4j/slf4j-api]]]
+                 [com.zaxxer/HikariCP-java6 "2.3.7" :exclusions [[org.slf4j/slf4j-api]]]
+                 [metrics-clojure "2.5.1" :exclusions [[org.slf4j/slf4j-api]]]
+                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/java.jdbc "0.3.6"]
+                 [org.postgresql/postgresql "9.4-1201-jdbc41"]
+                 [prismatic/schema "0.4.2"]
                  [puppetlabs/kitchensink ~ks-version]]
+
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper "1.1.1"]
+                                  [puppetlabs/trapperkeeper "1.1.1" :classifier "test"]]}}
+
+  :source-paths ["src/clj"]
+  :java-source-paths ["src/java"]
 
   :plugins [[lein-release "1.0.5"]]
 

--- a/src/clj/puppetlabs/jdbc_util/core.clj
+++ b/src/clj/puppetlabs/jdbc_util/core.clj
@@ -2,7 +2,9 @@
   (:import java.util.regex.Pattern)
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
-            [puppetlabs.kitchensink.core :as ks]))
+            [puppetlabs.jdbc-util.cp :as cp]
+            [puppetlabs.kitchensink.core :as ks]
+            [schema.core :as s]))
 
 (defn public-tables
   "Get the names of all public tables in a database"
@@ -105,3 +107,17 @@
                        [sql 0]
                        seq-params-w-indices)]
     (vec (conj (flatten parameters) sql'))))
+
+;; Connection pooling
+
+(s/defn ^:always-validate pooled-db-spec :- cp/pooled-db-spec-schema
+  "Given a database connection attribute map, return a JDBC datasource
+  compatible with clojure.java.jdbc that is backed by a connection
+  pool."
+  [pool-name options]
+  (cp/pooled-db-spec pool-name options))
+
+(s/defn ^:always-validate close-pooled-db-spec
+  "Close an open DataSource supplied as a JDBC compatible db-spec."
+  [db-spec :- cp/pooled-db-spec-schema]
+  (cp/close-pooled-db-spec db-spec))

--- a/src/clj/puppetlabs/jdbc_util/cp.clj
+++ b/src/clj/puppetlabs/jdbc_util/cp.clj
@@ -1,0 +1,180 @@
+(ns puppetlabs.jdbc-util.cp
+  "Connection pooling specific internals."
+  (:import com.codahale.metrics.MetricRegistry
+           com.zaxxer.hikari.HikariConfig
+           com.zaxxer.hikari.HikariDataSource
+           org.jdbcdslog.ConnectionPoolDataSourceProxy)
+  (:require [metrics.core :as metrics]
+            [schema.core :as s]))
+
+;; Defaults
+
+(def default-datasource-options
+  {;; Most clojure.java.jdbc usage means we don't want this on by default.
+   :auto-commit              false
+   ;; This means that by default, we retry until connection-timeout when
+   ;; initializing the pool.
+   :initialization-fail-fast false
+   ;; We presume always enabling JMX is a good idea
+   :register-mbeans          true
+   ;; Without explicit transaction isolation and a test query, we are unable
+   ;; to change the transaction isolation level on a per query basis since
+   ;; Connection.isAlive() tests aren't transactionally isolated.
+   :connection-test-query    "/* hikaricp test query */ select 1;"
+   :isolate-internal-queries true
+   ;; Statistics default settings
+   :stats                    true
+   :metrics-registry         metrics/default-registry})
+
+;; Schema
+
+(def pooled-db-spec-schema
+  "Schema representing a clojure.java.jdbc compatible pooled db-spec."
+  {:datasource javax.sql.DataSource})
+
+(defn- gte-0?
+  "Returns true if num is greater than or equal 0, else false"
+  [x]
+  (>= x 0))
+
+(defn- gte-1?
+  "Returns true if num is greater than or equal 1, else false"
+  [x]
+  (>= x 1))
+
+(defn- gte-1000?
+  "Returns true if num is greater than or equal 1000, else false"
+  [x]
+  (>= x 1000))
+
+(def ^{:private true} IntGte0
+  (s/both s/Int (s/pred gte-0? 'gte-0?)))
+
+(def ^{:private true} IntGte1
+  (s/both s/Int (s/pred gte-1? 'gte-1?)))
+
+(def ^{:private true} IntGte1000
+  (s/both s/Int (s/pred gte-1000? 'gte-1000?)))
+
+(def ConfigurationOptions
+  {:auto-commit                         s/Bool
+   (s/optional-key :classname)          s/Str
+   (s/optional-key :connection-timeout) IntGte1000
+   (s/optional-key :idle-timeout)       IntGte0
+   :initialization-fail-fast            s/Bool
+   (s/optional-key :max-lifetime)       IntGte0
+   (s/optional-key :maximum-pool-size)  IntGte1
+   :metrics-registry                    MetricRegistry
+   (s/optional-key :minimum-idle)       IntGte0
+   (s/optional-key :password)           s/Str
+   :pool-name                           s/Str
+   (s/optional-key :read-only)          (s/maybe s/Bool)
+   :register-mbeans                     s/Bool
+   :stats                               s/Bool
+   :subname                             s/Str
+   :subprotocol                         s/Str
+   (s/optional-key :validation-timeout) IntGte1000
+   (s/optional-key :user)               s/Str
+   :connection-test-query               s/Str
+   :isolate-internal-queries            s/Bool})
+
+;; Functions
+
+(s/defn ^:always-validate add-datasource-property
+  "Add a custom datasource property to the underlying database driver."
+  [config :- HikariConfig
+   property :- s/Str
+   value :- s/Str]
+  (.addDataSourceProperty config property value))
+
+(s/defn ^:always-validate add-datasource-properties
+  "Like add-datasource-property, but allows you to pass a map of properties and
+   values."
+  [config :- HikariConfig
+   properties :- {s/Str s/Str}]
+  (doseq [[k v] properties]
+    (add-datasource-property config k v)))
+
+(defn validate-options
+  "Manage defaulting and validation of options."
+  [options]
+  (s/validate ConfigurationOptions (merge default-datasource-options options)))
+
+(s/defn ^:always-validate datasource-config :- HikariConfig
+  "Produce a valid HikariConfig object from provided configuration options."
+  [datasource-options]
+  (let [config (HikariConfig.)
+        options (validate-options datasource-options)
+        {:keys [adapter
+                auto-commit
+                connection-test-query
+                connection-timeout
+                idle-timeout
+                initialization-fail-fast
+                internal-test-query
+                isolate-internal-queries
+                max-lifetime
+                maximum-pool-size
+                metrics-registry
+                minimum-idle
+                password
+                pool-name
+                read-only
+                register-mbeans
+                stats
+                subname
+                subprotocol
+                user
+                validation-timeout]} options]
+
+    ;; Set pool-specific properties
+    (doto config
+      (.setAutoCommit auto-commit)
+      (.setInitializationFailFast initialization-fail-fast)
+      (.setRegisterMbeans register-mbeans)
+      (.setJdbcUrl (str "jdbc:" subprotocol ":" subname))
+      (.setIsolateInternalQueries isolate-internal-queries)
+      (.setConnectionTestQuery connection-test-query)
+      (.setPoolName pool-name))
+
+    ;; Set optional properties
+    (when stats (.setMetricRegistry config metrics-registry))
+    (when read-only (.setReadOnly config read-only))
+    (when idle-timeout (.setIdleTimeout config idle-timeout))
+    (when max-lifetime (.setMaxLifetime config max-lifetime))
+    (when minimum-idle (.setMinimumIdle config minimum-idle))
+    (when maximum-pool-size (.setMaximumPoolSize config maximum-pool-size))
+    (when validation-timeout (.setValidationTimeout config validation-timeout))
+    (when connection-timeout (.setConnectionTimeout config connection-timeout))
+    (when user (.setUsername config user))
+    (when password (.setPassword config password))
+
+    ;; Set driver specific properties
+    (case subprotocol
+      "postgresql" (add-datasource-properties config {"ApplicationName" pool-name
+                                                      "tcpKeepAlive" "true"
+                                                      "logUnclosedConnections" "true"})
+      "default")
+
+    config))
+
+(defn pooled-db-spec
+  "Create a pooled clojure.java.jdbc compatible db-spec."
+  [pool-name options]
+  (let [options (assoc options :pool-name pool-name)
+        config (datasource-config options)
+        orig-ds (HikariDataSource. config)
+        jdbcdslog (ConnectionPoolDataSourceProxy.)
+        _ (doto jdbcdslog
+            (.setTargetDSDirect orig-ds))]
+    {:datasource jdbcdslog}))
+
+(s/defn ^:always-validate close-pooled-db-spec
+  "Close an open DataSource supplied as a clojure.java.jdbc compatible db-spec."
+  [db-spec :- pooled-db-spec-schema]
+  (let [ds (:datasource db-spec)
+        ;; Retrieve target DS, if we are using the connection proxy
+        ds (if (instance? org.jdbcdslog.ConnectionPoolDataSourceProxy ds)
+             (.getTargetDSDirect ds)
+             ds)]
+    (.close ds)))

--- a/src/java/org/jdbcdslog/CallableStatementLoggingHandler.java
+++ b/src/java/org/jdbcdslog/CallableStatementLoggingHandler.java
@@ -1,0 +1,68 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class CallableStatementLoggingHandler extends PreparedStatementLoggingHandler implements InvocationHandler {
+
+    static Logger logger = LoggerFactory.getLogger(CallableStatementLoggingHandler.class);
+
+    TreeMap namedParameters = new TreeMap();
+
+    public CallableStatementLoggingHandler(CallableStatement ps, String sql) {
+        super(ps, sql);
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String methodName = "invoke() ";
+        if (logger.isDebugEnabled())
+            logger.debug(methodName + "method = " + method);
+        Object r = null;
+        try {
+            boolean toLog = (StatementLogger.isDebugEnabled() || SlowQueryLogger.isDebugEnabled()) && executeMethods.contains(method.getName());
+            long t1 = 0;
+            if (toLog)
+                t1 = System.currentTimeMillis();
+            if (logger.isDebugEnabled())
+                logger.debug(methodName + "before method call..");
+            r = method.invoke(target, args);
+            if (logger.isDebugEnabled())
+                logger.debug(methodName + "after method call. result = " + r);
+            if (setMethods.contains(method.getName()) && args[0] instanceof Integer)
+                parameters.put(args[0], args[1]);
+            if (setMethods.contains(method.getName()) && args[0] instanceof String)
+                namedParameters.put(args[0], args[1]);
+            if ("clearParameters".equals(method.getName()))
+                parameters = new TreeMap();
+            if (toLog) {
+                long t2 = System.currentTimeMillis();
+                long time = t2 - t1;
+
+                StringBuffer s = LogUtils.createLogEntry(method, sql, parameters, namedParameters);
+
+                if (ConfigurationParameters.showTime) {
+                    s.append(" ").append(t2 - t1).append(" ms.");
+                }
+
+                StatementLogger.debug(s.toString());
+
+                if (time >= ConfigurationParameters.slowQueryThreshold) {
+                    SlowQueryLogger.debug(s.toString());
+                }
+            }
+            if (r instanceof ResultSet)
+                r = ResultSetLoggingHandler.wrapByResultSetProxy((ResultSet) r);
+        } catch (Throwable t) {
+            LogUtils.handleException(t, StatementLogger.getLogger(), LogUtils.createLogEntry(method, sql, parameters, namedParameters));
+        }
+        return r;
+    }
+
+}

--- a/src/java/org/jdbcdslog/ConfigurationParameters.java
+++ b/src/java/org/jdbcdslog/ConfigurationParameters.java
@@ -1,0 +1,157 @@
+package org.jdbcdslog;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigurationParameters {
+
+    /**
+     * All JDBCDSLog Properties.
+     *
+     * @author ShunLi
+     */
+    protected interface JDBCDSLogProperties {
+        String logText = "jdbcdslog.logText";
+        String printStackTrace = "jdbcdslog.printStackTrace";
+        String showTime = "jdbcdslog.showTime";
+        String allowedMultiDbs = "jdbcdslog.allowedMultiDbs";
+        String slowQueryThreshold = "jdbcdslog.slowQueryThreshold";
+        String driverName = "jdbcdslog.driverName";
+    }
+
+    private static Logger logger = LoggerFactory.getLogger(ConfigurationParameters.class);
+    private static Properties props;
+
+    static long slowQueryThreshold = Long.MAX_VALUE;
+    static boolean logText = false;
+    static Boolean showTime = false;
+    static boolean allowedMultiDbs = false;
+    static boolean printStackTrace = false;
+    static RdbmsSpecifics defaultRdbmsSpecifics = new OracleRdbmsSpecifics();
+    static RdbmsSpecifics rdbmsSpecifics = defaultRdbmsSpecifics; // oracle is default db.
+
+    static Map<String, RdbmsSpecifics> rdbmsSpecificsMap = new HashMap<String, RdbmsSpecifics>();
+
+    static {
+        ClassLoader loader = ConfigurationParameters.class.getClassLoader();
+        InputStream in = null;
+        try {
+            in = loader.getResourceAsStream("jdbcdslog.properties");
+            props = new Properties(System.getProperties());
+            if (in != null) {
+                props.load(in);
+            }
+
+            logText = getBooleanProp(JDBCDSLogProperties.logText, logText);
+            printStackTrace = getBooleanProp(JDBCDSLogProperties.printStackTrace, printStackTrace);
+            showTime = getBooleanProp(JDBCDSLogProperties.showTime, showTime);
+            allowedMultiDbs = getBooleanProp(JDBCDSLogProperties.allowedMultiDbs, allowedMultiDbs);
+
+            initSlowQueryThreshold();
+            initRdbmsSpecificsMap();
+            initRdbmsSpecifics();
+
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        } finally {
+            if (in != null)
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    logger.error(e.getMessage(), e);
+                }
+        }
+    }
+
+    /* init parameters start. */
+    private static void initSlowQueryThreshold() {
+        String isSlowQueryThreshold = props.getProperty(JDBCDSLogProperties.slowQueryThreshold);
+        if (isSlowQueryThreshold != null && isLong(isSlowQueryThreshold)) {
+            slowQueryThreshold = Long.parseLong(isSlowQueryThreshold);
+        }
+        if (slowQueryThreshold == -1) {
+            slowQueryThreshold = Long.MAX_VALUE;
+        }
+    }
+
+    private static boolean getBooleanProp(String propKey, boolean defaultValue) {
+        return "true".equalsIgnoreCase(props.getProperty(propKey, String.valueOf(defaultValue)));
+    }
+
+    private static void initRdbmsSpecificsMap() {
+        // key will turn Lower Case. and default rdbmsSpecifics is oralce , so exclude Oracle related.
+        RdbmsSpecifics mySqlRdbmsSpecifics = new MySqlRdbmsSpecifics();
+        RdbmsSpecifics sqlServerRdbmsSpecifics = new SqlServerRdbmsSpecifics();
+
+        rdbmsSpecificsMap.put("oracle", defaultRdbmsSpecifics);
+        rdbmsSpecificsMap.put("mysql", mySqlRdbmsSpecifics);
+        rdbmsSpecificsMap.put("sqlserver", sqlServerRdbmsSpecifics);
+        // if you have more rdbms specifice, defind it in here.
+    }
+
+    private static void initRdbmsSpecifics() {
+        loadRdbmsSpecificsFromMap(props.getProperty(JDBCDSLogProperties.driverName));
+    }
+
+    /* init parameters end. */
+
+    public static void setLogText(boolean alogText) {
+        logText = alogText;
+    }
+
+    private static boolean isLong(String sSlowQueryThreshold) {
+        try {
+            Long.parseLong(sSlowQueryThreshold);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * support specific info should be got from connection specific database vendor
+     *
+     * @param driverName
+     */
+    public static void reloadRdbmsSpecificsFromConnection(String driverName) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Reload Rdbms Specifics From Connection: " + driverName);
+        }
+        loadRdbmsSpecificsFromMap(driverName);
+    }
+
+    /**
+     * @param driverName
+     */
+    private static void loadRdbmsSpecificsFromMap(String driverName) {
+        if (driverName != null) {
+            String capitalizedDriverName = driverName.toLowerCase();
+
+            if (rdbmsSpecificsMap.containsKey(capitalizedDriverName)) {
+                rdbmsSpecifics = rdbmsSpecificsMap.get(capitalizedDriverName);
+            } else {
+                boolean find = false;
+
+                for (String key : rdbmsSpecificsMap.keySet()) {
+                    find = capitalizedDriverName.indexOf(key) >= 0;
+
+                    if (find) {
+                        rdbmsSpecifics = rdbmsSpecificsMap.get(key);
+                        rdbmsSpecificsMap.put(capitalizedDriverName, rdbmsSpecifics);
+                        break;
+                    }
+                }
+
+                if (!find) {
+                    rdbmsSpecificsMap.put(capitalizedDriverName, rdbmsSpecifics); // = the recent rdbms specifics.
+                }
+            }
+        }
+    }
+}

--- a/src/java/org/jdbcdslog/ConnectionLogger.java
+++ b/src/java/org/jdbcdslog/ConnectionLogger.java
@@ -1,0 +1,32 @@
+package org.jdbcdslog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConnectionLogger {
+    private static Logger logger = LoggerFactory.getLogger(ConnectionLogger.class);
+
+    public static void debug(String s) {
+        logger.debug(s + LogUtils.getStackTrace());
+    }
+
+    public static void info(String s) {
+        logger.info(s + LogUtils.getStackTrace());
+    }
+
+    public static void error(String m, Throwable t) {
+        logger.error(m, t);
+    }
+
+    public static boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    public static boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/java/org/jdbcdslog/ConnectionLoggingProxy.java
+++ b/src/java/org/jdbcdslog/ConnectionLoggingProxy.java
@@ -1,0 +1,12 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+
+public class ConnectionLoggingProxy {
+
+    public static Connection wrap(Connection con) {
+        return (Connection) Proxy.newProxyInstance(con.getClass().getClassLoader(), new Class[] { Connection.class }, new GenericLoggingHandler(con));
+    }
+
+}

--- a/src/java/org/jdbcdslog/ConnectionPoolDataSourceProxy.java
+++ b/src/java/org/jdbcdslog/ConnectionPoolDataSourceProxy.java
@@ -1,0 +1,22 @@
+package org.jdbcdslog;
+
+import java.util.logging.Logger;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+
+public class ConnectionPoolDataSourceProxy extends DataSourceProxyBase implements DataSource, ConnectionPoolDataSource {
+
+    private static final long serialVersionUID = 5094791657099299920L;
+
+    public ConnectionPoolDataSourceProxy() throws JDBCDSLogException {
+        super();
+    }
+
+    public Logger getParentLogger() {
+        return null;
+    }
+
+    public Object unwrap(Class targetClass) {
+        return null;
+    }
+}

--- a/src/java/org/jdbcdslog/ConnectionPoolXADataSourceProxy.java
+++ b/src/java/org/jdbcdslog/ConnectionPoolXADataSourceProxy.java
@@ -1,0 +1,24 @@
+package org.jdbcdslog;
+
+import java.util.logging.Logger;
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+public class ConnectionPoolXADataSourceProxy extends DataSourceProxyBase implements DataSource, XADataSource, ConnectionPoolDataSource {
+
+    private static final long serialVersionUID = 5829721261280763559L;
+
+    public ConnectionPoolXADataSourceProxy() throws JDBCDSLogException {
+        super();
+    }
+
+    public Logger getParentLogger() {
+        return null;
+    }
+
+    public Object unwrap(Class targetClass) {
+        return null;
+    }
+
+}

--- a/src/java/org/jdbcdslog/DataSourceProxy.java
+++ b/src/java/org/jdbcdslog/DataSourceProxy.java
@@ -1,0 +1,22 @@
+package org.jdbcdslog;
+
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+public class DataSourceProxy extends DataSourceProxyBase implements DataSource {
+
+    private static final long serialVersionUID = -6888072076120346186L;
+
+    public DataSourceProxy() throws JDBCDSLogException {
+        super();
+    }
+
+    public Logger getParentLogger() {
+        return null;
+    }
+
+    public Object unwrap(Class targetClass) {
+        return null;
+    }
+
+}

--- a/src/java/org/jdbcdslog/DataSourceProxyBase.java
+++ b/src/java/org/jdbcdslog/DataSourceProxyBase.java
@@ -1,0 +1,282 @@
+package org.jdbcdslog;
+
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.PooledConnection;
+import javax.sql.XAConnection;
+import javax.sql.XADataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({"unchecked","rawtypes"})
+public class DataSourceProxyBase implements Serializable {
+
+    private static final long serialVersionUID = -1209576641924549514L;
+
+    static Logger logger = LoggerFactory.getLogger(DataSourceProxyBase.class);
+
+    static final String targetDSParameter = "targetDS";
+
+    Object targetDS = null;
+
+    Map props = new HashMap();
+
+    Map propClasses = new HashMap();
+
+    public DataSourceProxyBase() throws JDBCDSLogException {
+    }
+
+    public Connection getConnection() throws SQLException {
+
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof DataSource) {
+            Connection con = ((DataSource) targetDS).getConnection();
+            if (ConnectionLogger.isDebugEnabled())
+                ConnectionLogger.debug("connect to URL " + con.getMetaData().getURL() + " for user " + con.getMetaData().getUserName());
+            return ConnectionLoggingProxy.wrap(con);
+        } else
+            throw new SQLException("targetDS doesn't implement DataSource interface.");
+    }
+
+    public Connection getConnection(String username, String password) throws SQLException {
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof DataSource) {
+            Connection con = ((DataSource) targetDS).getConnection(username, password);
+            if (ConnectionLogger.isDebugEnabled())
+                ConnectionLogger.debug("connect to URL " + con.getMetaData().getURL() + " for user " + con.getMetaData().getUserName());
+            return ConnectionLoggingProxy.wrap(con);
+        } else
+            throw new SQLException("targetDS doesn't implement DataSource interface.");
+    }
+
+    public PrintWriter getLogWriter() throws SQLException {
+        if (targetDS instanceof DataSource)
+            return ((DataSource) targetDS).getLogWriter();
+        if (targetDS instanceof XADataSource)
+            return ((XADataSource) targetDS).getLogWriter();
+        if (targetDS instanceof ConnectionPoolDataSource)
+            return ((ConnectionPoolDataSource) targetDS).getLogWriter();
+        throw new SQLException("targetDS doesn't have getLogWriter() method");
+    }
+
+    public int getLoginTimeout() throws SQLException {
+        if (targetDS instanceof DataSource)
+            return ((DataSource) targetDS).getLoginTimeout();
+        if (targetDS instanceof XADataSource)
+            return ((XADataSource) targetDS).getLoginTimeout();
+        if (targetDS instanceof ConnectionPoolDataSource)
+            return ((ConnectionPoolDataSource) targetDS).getLoginTimeout();
+        throw new SQLException("targetDS doesn't have getLogTimeout() method");
+    }
+
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        if (targetDS instanceof DataSource)
+            ((DataSource) targetDS).setLogWriter(out);
+        if (targetDS instanceof XADataSource)
+            ((XADataSource) targetDS).setLogWriter(out);
+        if (targetDS instanceof ConnectionPoolDataSource)
+            ((ConnectionPoolDataSource) targetDS).setLogWriter(out);
+        throw new SQLException("targetDS doesn't have setLogWriter() method");
+    }
+
+    public void setLoginTimeout(int seconds) throws SQLException {
+        if (targetDS instanceof DataSource)
+            ((DataSource) targetDS).setLoginTimeout(seconds);
+        if (targetDS instanceof XADataSource)
+            ((XADataSource) targetDS).setLoginTimeout(seconds);
+        if (targetDS instanceof ConnectionPoolDataSource)
+            ((ConnectionPoolDataSource) targetDS).setLoginTimeout(seconds);
+        throw new SQLException("targetDS doesn't have setLogWriter() method");
+    }
+
+    public XAConnection getXAConnection() throws SQLException {
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof XADataSource) {
+            XAConnection con = ((XADataSource) targetDS).getXAConnection();
+            return XAConnectionLoggingProxy.wrap(con);
+        } else
+            throw new SQLException("targetDS doesn't implement XADataSource interface.");
+    }
+
+    public XAConnection getXAConnection(String user, String password) throws SQLException {
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof XADataSource)
+            return XAConnectionLoggingProxy.wrap(((XADataSource) targetDS).getXAConnection(user, password));
+        else
+            throw new SQLException("targetDS doesn't implement XADataSource interface.");
+    }
+
+    public PooledConnection getPooledConnection() throws SQLException {
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof ConnectionPoolDataSource)
+            return PooledConnectionLoggingProxy.wrap(((ConnectionPoolDataSource) targetDS).getPooledConnection());
+        else
+            throw new SQLException("targetDS doesn't implement ConnectionPoolDataSource interface.");
+    }
+
+    public PooledConnection getPooledConnection(String user, String password) throws SQLException {
+        if (targetDS == null)
+            throw new SQLException("targetDS parameter has not been passed to Database or URL property.");
+        if (targetDS instanceof ConnectionPoolDataSource)
+            return PooledConnectionLoggingProxy.wrap(((ConnectionPoolDataSource) targetDS).getPooledConnection(user, password));
+        else
+            throw new SQLException("targetDS doesn't implement ConnectionPoolDataSource interface.");
+    }
+
+    void invokeTargetSetMethod(String m, Object p, Class c) {
+        // String methodName = "invokeTargetSetMethod() ";
+        if (targetDS == null) {
+            props.put(m, p);
+            propClasses.put(m, c);
+            return;
+        }
+        logger.debug(m + "(" + p.toString() + ")");
+        try {
+            Method me = targetDS.getClass().getMethod(m, c);
+            if (me != null)
+                me.invoke(targetDS, p);
+        } catch (Exception e) {
+            ConnectionLogger.error(e.getMessage(), e);
+        }
+    }
+
+    public void setURL(String url) throws JDBCDSLogException {
+        url = initTargetDS(url);
+        invokeTargetSetMethod("setURL", url, String.class);
+    }
+
+    private String initTargetDS(String url) throws JDBCDSLogException {
+        String methodName = "initTargedDS() ";
+        logger.debug(methodName + "url = " + url + " targedDS = " + targetDS);
+        try {
+            if (url == null || targetDS != null)
+                return url;
+            logger.debug("Parse url.");
+            StringTokenizer ts = new StringTokenizer(url, ":/;=&?", false);
+            String targetDSName = null;
+            while (ts.hasMoreTokens()) {
+                String s = ts.nextToken();
+                logger.debug("s = " + s);
+                if (targetDSParameter.equals(s) && ts.hasMoreTokens()) {
+                    targetDSName = ts.nextToken();
+                    break;
+                }
+            }
+            if (targetDSName == null)
+                return url;
+            url = url.substring(0, url.length() - targetDSName.length() - targetDSParameter.length() - 2);
+            setTargetDS(targetDSName);
+            return url;
+        } catch (Throwable t) {
+            ConnectionLogger.error(t.getMessage(), t);
+            throw new JDBCDSLogException(t);
+        }
+    }
+
+    public void setTargetDSDirect(Object dataSource) {
+        String methodName = "setTargetDSDirect() ";
+        targetDS = dataSource;
+        logger.debug(methodName + "targetDS initialized.");
+    }
+
+    public Object getTargetDSDirect() {
+        return targetDS;
+    }
+
+    public void setTargetDS(String targetDSName) throws JDBCDSLogException, InstantiationException, IllegalAccessException {
+        String methodName = "setTargetDS() ";
+        try {
+            Class cl = Class.forName(targetDSName);
+            if (cl == null)
+                throw new JDBCDSLogException("Can't load class of targetDS.");
+            Object targetObj = cl.newInstance();
+            targetDS = targetObj;
+            logger.debug(methodName + "targetDS initialized.");
+            setPropertiesForTargetDS();
+        } catch (Throwable t) {
+            ConnectionLogger.error(t.getMessage(), t);
+            throw new JDBCDSLogException(t);
+        }
+    }
+
+    private void setPropertiesForTargetDS() {
+        for (Iterator i = props.keySet().iterator(); i.hasNext();) {
+            String m = (String) i.next();
+            invokeTargetSetMethod(m, props.get(m), (Class) propClasses.get(m));
+        }
+    }
+
+    public void setDatabaseName(String p) {
+        invokeTargetSetMethod("setDatabaseName", p, String.class);
+    }
+
+    public void setDescription(String p) {
+        invokeTargetSetMethod("setDescription", p, String.class);
+    }
+
+    public void setDataSourceName(String p) {
+        invokeTargetSetMethod("setDataSourceName", p, String.class);
+    }
+
+    public void setDriverType(String p) {
+        invokeTargetSetMethod("setDriverType", p, String.class);
+    }
+
+    public void setNetworkProtocol(String p) {
+        invokeTargetSetMethod("setNetworkProtocol", p, String.class);
+    }
+
+    public void setPassword(String p) {
+        invokeTargetSetMethod("setPassword", p, String.class);
+    }
+
+    public void setPortNumber(int p) {
+        invokeTargetSetMethod("setPortNumber", new Integer(p), int.class);
+    }
+
+    public void setServerName(String p) {
+        invokeTargetSetMethod("setServerName", p, String.class);
+    }
+
+    public void setServiceName(String p) {
+        invokeTargetSetMethod("setServiceName", p, String.class);
+    }
+
+    public void setTNSEntryName(String p) {
+        invokeTargetSetMethod("setTNSEntryName", p, String.class);
+    }
+
+    public void setUser(String p) {
+        invokeTargetSetMethod("setUser", p, String.class);
+    }
+
+    public void setDatabase(String p) throws JDBCDSLogException {
+        p = initTargetDS(p);
+        invokeTargetSetMethod("setDatabase", p, String.class);
+    }
+
+    public boolean isWrapperFor(Class iface) throws SQLException {
+        return false;
+    }
+
+    public Object unwrap(Class iface) throws SQLException {
+        return null;
+    }
+
+}

--- a/src/java/org/jdbcdslog/DriverLoggingProxy.java
+++ b/src/java/org/jdbcdslog/DriverLoggingProxy.java
@@ -1,0 +1,122 @@
+package org.jdbcdslog;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DriverLoggingProxy implements Driver {
+
+    static Logger logger = LoggerFactory.getLogger(DriverLoggingProxy.class);
+
+    static final String urlPrefix = "jdbc:jdbcdslog:";
+
+    static final String targetDriverParameter = "targetDriver";
+
+    static {
+        try {
+            DriverManager.registerDriver(new DriverLoggingProxy());
+        } catch (Exception exception) {
+            ConnectionLogger.error(exception.getMessage(), exception);
+        }
+    }
+
+    public DriverLoggingProxy() throws JDBCDSLogException {
+    }
+
+    public boolean acceptsURL(String url) throws SQLException {
+        return url != null && url.regionMatches(true, 0, urlPrefix, 0, urlPrefix.length());
+    }
+
+    public Connection connect(String url, Properties info) throws SQLException {
+        if (ConnectionLogger.isDebugEnabled()) {
+            StringBuffer sb = new StringBuffer();
+            sb.append("connect to URL ").append(url).append(" with properties: ").append(info.toString());
+            ConnectionLogger.debug(sb.toString());
+        }
+        if (!acceptsURL(url))
+            throw new SQLException("Invalid URL" + url);
+        url = "jdbc:" + url.substring(urlPrefix.length());
+        StringTokenizer ts = new StringTokenizer(url, ":/;=&?", false);
+        String targetDriver = null;
+        while (ts.hasMoreTokens()) {
+            String s = ts.nextToken();
+            logger.debug("s = " + s);
+            if (targetDriverParameter.equals(s) && ts.hasMoreTokens()) {
+                targetDriver = ts.nextToken();
+                break;
+            }
+        }
+        if (targetDriver == null)
+            throw new SQLException("Can't find targetDriver parameter in URL: " + url);
+        url = url.substring(0, url.length() - targetDriver.length() - targetDriverParameter.length() - 2);
+        try {
+            Class.forName(targetDriver);
+            return ConnectionLoggingProxy.wrap(DriverManager.getConnection(url, info));
+        } catch (Exception e) {
+            ConnectionLogger.error(e.getMessage(), e);
+            throw new SQLException(e.getMessage());
+        }
+    }
+
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    public int getMinorVersion() {
+        return 8;
+    }
+
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties properties) throws SQLException {
+        String as[] = { "true", "false" };
+        DriverPropertyInfo adriverpropertyinfo[] = new DriverPropertyInfo[6];
+        DriverPropertyInfo driverpropertyinfo = new DriverPropertyInfo("user", null);
+        driverpropertyinfo.value = properties.getProperty("user");
+        driverpropertyinfo.required = true;
+        adriverpropertyinfo[0] = driverpropertyinfo;
+        driverpropertyinfo = new DriverPropertyInfo("password", null);
+        driverpropertyinfo.value = properties.getProperty("password");
+        driverpropertyinfo.required = true;
+        adriverpropertyinfo[1] = driverpropertyinfo;
+        driverpropertyinfo = new DriverPropertyInfo("get_column_name", null);
+        driverpropertyinfo.value = properties.getProperty("get_column_name", "true");
+        driverpropertyinfo.required = false;
+        driverpropertyinfo.choices = as;
+        adriverpropertyinfo[2] = driverpropertyinfo;
+        driverpropertyinfo = new DriverPropertyInfo("ifexists", null);
+        driverpropertyinfo.value = properties.getProperty("ifexists");
+        driverpropertyinfo.required = false;
+        driverpropertyinfo.choices = as;
+        adriverpropertyinfo[3] = driverpropertyinfo;
+        driverpropertyinfo = new DriverPropertyInfo("default_schema", null);
+        driverpropertyinfo.value = properties.getProperty("default_schema");
+        driverpropertyinfo.required = false;
+        driverpropertyinfo.choices = as;
+        adriverpropertyinfo[4] = driverpropertyinfo;
+        driverpropertyinfo = new DriverPropertyInfo("shutdown", null);
+        driverpropertyinfo.value = properties.getProperty("shutdown");
+        driverpropertyinfo.required = false;
+        driverpropertyinfo.choices = as;
+        adriverpropertyinfo[5] = driverpropertyinfo;
+        return adriverpropertyinfo;
+    }
+
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    public java.util.logging.Logger getParentLogger() {
+        return null;
+    }
+
+    public Object unwrap(Class targetClass) {
+        return null;
+    }
+
+}

--- a/src/java/org/jdbcdslog/GenericLoggingHandler.java
+++ b/src/java/org/jdbcdslog/GenericLoggingHandler.java
@@ -1,0 +1,82 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+@SuppressWarnings("rawtypes")
+public class GenericLoggingHandler implements InvocationHandler {
+    String sql = null;
+
+    Object target = null;
+
+    public GenericLoggingHandler(Object target) {
+        this.target = target;
+    }
+
+    public GenericLoggingHandler(Object target, String sql) {
+        this.target = target;
+        this.sql = sql;
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        try {
+            Object r = method.invoke(target, args);
+
+            // 1. check is allowed muitl driver
+            if (ConfigurationParameters.allowedMultiDbs) {
+                // 2. reload when connection
+                ConfigurationParameters.reloadRdbmsSpecificsFromConnection(target.getClass().getName());
+            }
+
+            if (method.getName().equals("prepareCall") || method.getName().equals("prepareStatement"))
+                r = wrap(r, (String) args[0]);
+            else
+                r = wrap(r, null);
+            return r;
+        } catch (Throwable t) {
+            LogUtils.handleException(t, ConnectionLogger.getLogger(), LogUtils.createLogEntry(method, null, null, null));
+        }
+        return null;
+    }
+
+    private Object wrap(Object r, String sql) throws Exception {
+        if (r instanceof Connection) {
+            Connection con = (Connection) r;
+            if (ConnectionLogger.isDebugEnabled())
+                ConnectionLogger.debug("connect to URL " + con.getMetaData().getURL() + " for user " + con.getMetaData().getUserName());
+            return wrapByGenericProxy(r, Connection.class, sql);
+        }
+        if (r instanceof CallableStatement)
+            return wrapByCallableStatementProxy(r, sql);
+        if (r instanceof PreparedStatement)
+            return wrapByPreparedStatementProxy(r, sql);
+        if (r instanceof Statement)
+            return wrapByStatementProxy(r);
+        if (r instanceof ResultSet)
+            return ResultSetLoggingHandler.wrapByResultSetProxy((ResultSet) r);
+        return r;
+    }
+
+    private Object wrapByStatementProxy(Object r) {
+        return Proxy.newProxyInstance(r.getClass().getClassLoader(), new Class[] { Statement.class }, new StatementLoggingHandler((Statement) r));
+    }
+
+    private Object wrapByPreparedStatementProxy(Object r, String sql) {
+        return Proxy.newProxyInstance(r.getClass().getClassLoader(), new Class[] { PreparedStatement.class }, new PreparedStatementLoggingHandler((PreparedStatement) r, sql));
+    }
+
+    private Object wrapByCallableStatementProxy(Object r, String sql) {
+        return Proxy.newProxyInstance(r.getClass().getClassLoader(), new Class[] { CallableStatement.class }, new CallableStatementLoggingHandler((CallableStatement) r, sql));
+    }
+
+    static Object wrapByGenericProxy(Object r, Class interf, String sql) {
+        return Proxy.newProxyInstance(r.getClass().getClassLoader(), new Class[] { interf }, new GenericLoggingHandler(r, sql));
+    }
+
+}

--- a/src/java/org/jdbcdslog/JDBCDSLogException.java
+++ b/src/java/org/jdbcdslog/JDBCDSLogException.java
@@ -1,0 +1,13 @@
+package org.jdbcdslog;
+
+public class JDBCDSLogException extends Exception {
+    private static final long serialVersionUID = 2791270426551839139L;
+
+    public JDBCDSLogException(String s) {
+        super(s);
+    }
+
+    public JDBCDSLogException(Throwable e) {
+        super(e);
+    }
+}

--- a/src/java/org/jdbcdslog/LogUtils.java
+++ b/src/java/org/jdbcdslog/LogUtils.java
@@ -1,0 +1,212 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("rawtypes")
+public class LogUtils {
+
+    static Logger logger = LoggerFactory.getLogger(LogUtils.class);
+
+    private final static String NAMED_PARAMETERS_PREFIX = ":";
+
+    public static void handleException(Throwable e, Logger l, StringBuffer msg) throws Throwable {
+        if (e instanceof InvocationTargetException) {
+            Throwable t = ((InvocationTargetException) e).getTargetException();
+            if (l.isErrorEnabled())
+                l.error(msg + "\nthrows exception: " + t.getClass().getName() + ": " + t.getMessage(), t);
+            throw t;
+        } else {
+            if (l.isErrorEnabled())
+                l.error(msg + "\nthrows exception: " + e.getClass().getName() + ": " + e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    public static StringBuffer createLogEntry(Method method, String sql, TreeMap parameters, TreeMap namedParameters) {
+        StringBuffer s = new StringBuffer();
+        if (method != null) {
+            s.append(method.getDeclaringClass().getName()).append(".").append(method.getName()).append(": ");
+        }
+
+        if (parameters != null && !parameters.isEmpty()) {
+            s.append(createLogEntry(sql, parameters));
+        } else {
+            s.append(createLogEntryForNamedParameters(sql, namedParameters));
+        }
+
+        return s;
+    }
+
+    public static StringBuffer createLogEntry(String sql, TreeMap parameters) {
+        StringBuffer s = new StringBuffer();
+
+        if (sql != null) {
+            int questionMarkCount = 1;
+            Pattern p = Pattern.compile("\\?");
+            Matcher m = p.matcher(sql);
+            StringBuffer stringBuffer = new StringBuffer();
+
+            while (m.find()) {
+                m.appendReplacement(stringBuffer, ConfigurationParameters.rdbmsSpecifics.formatParameter(parameters.get(questionMarkCount)));
+                questionMarkCount++;
+            }
+            sql = String.valueOf(m.appendTail(stringBuffer));
+
+            s.append(sql).append(";");
+        }
+
+        return s;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static StringBuffer createLogEntryForNamedParameters(String sql, TreeMap namedParameters) {
+        StringBuffer s = new StringBuffer();
+
+        if (sql != null) {
+            if (namedParameters != null && !namedParameters.isEmpty()) {
+                for (String key : (Set<String>) namedParameters.keySet()) {
+                    sql = sql.replaceAll(NAMED_PARAMETERS_PREFIX + key, ConfigurationParameters.rdbmsSpecifics.formatParameter(namedParameters.get(key)));
+                }
+            }
+            s.append(sql).append(";");
+        }
+
+        return s;
+    }
+
+    public static String getStackTrace() {
+        if (!ConfigurationParameters.printStackTrace)
+            return "";
+        StackTraceElement stackTraces[] = new Throwable().getStackTrace();
+        StringBuffer sb = new StringBuffer(" at ");
+        sb.append(stackTraces[4]);
+        return sb.toString();
+    }
+
+    // Refer apache common lang StringUtils.
+    public static String replaceEach(String text, String[] searchList, String[] replacementList) {
+
+        // mchyzer Performance note: This creates very few new objects (one major goal)
+        // let me know if there are performance requests, we can create a harness to measure
+
+        if (text == null || text.length() == 0 || searchList == null ||
+                searchList.length == 0 || replacementList == null || replacementList.length == 0) {
+            return text;
+        }
+
+        int searchLength = searchList.length;
+        int replacementLength = replacementList.length;
+
+        // make sure lengths are ok, these need to be equal
+        if (searchLength != replacementLength) {
+            throw new IllegalArgumentException("Search and Replace array lengths don't match: "
+                    + searchLength
+                    + " vs "
+                    + replacementLength);
+        }
+
+        // keep track of which still have matches
+        boolean[] noMoreMatchesForReplIndex = new boolean[searchLength];
+
+        // index on index that the match was found
+        int textIndex = -1;
+        int replaceIndex = -1;
+        int tempIndex = -1;
+
+        // index of replace array that will replace the search string found
+        // NOTE: logic duplicated below START
+        for (int i = 0; i < searchLength; i++) {
+            if (noMoreMatchesForReplIndex[i] || searchList[i] == null ||
+                    searchList[i].length() == 0 || replacementList[i] == null) {
+                continue;
+            }
+            tempIndex = text.indexOf(searchList[i]);
+
+            // see if we need to keep searching for this
+            if (tempIndex == -1) {
+                noMoreMatchesForReplIndex[i] = true;
+            } else {
+                if (textIndex == -1 || tempIndex < textIndex) {
+                    textIndex = tempIndex;
+                    replaceIndex = i;
+                }
+            }
+        }
+        // NOTE: logic mostly below END
+
+        // no search strings found, we are done
+        if (textIndex == -1) {
+            return text;
+        }
+
+        int start = 0;
+
+        // get a good guess on the size of the result buffer so it doesn't have to double if it goes over a bit
+        int increase = 0;
+
+        // count the replacement text elements that are larger than their corresponding text being replaced
+        for (int i = 0; i < searchList.length; i++) {
+            if (searchList[i] == null || replacementList[i] == null) {
+                continue;
+            }
+            int greater = replacementList[i].length() - searchList[i].length();
+            if (greater > 0) {
+                increase += 3 * greater; // assume 3 matches
+            }
+        }
+        // have upper-bound at 20% increase, then let Java take over
+        increase = Math.min(increase, text.length() / 5);
+
+        StringBuilder buf = new StringBuilder(text.length() + increase);
+
+        while (textIndex != -1) {
+
+            for (int i = start; i < textIndex; i++) {
+                buf.append(text.charAt(i));
+            }
+            buf.append(replacementList[replaceIndex]);
+
+            start = textIndex + searchList[replaceIndex].length();
+
+            textIndex = -1;
+            replaceIndex = -1;
+            tempIndex = -1;
+            // find the next earliest match
+            // NOTE: logic mostly duplicated above START
+            for (int i = 0; i < searchLength; i++) {
+                if (noMoreMatchesForReplIndex[i] || searchList[i] == null ||
+                        searchList[i].length() == 0 || replacementList[i] == null) {
+                    continue;
+                }
+                tempIndex = text.indexOf(searchList[i], start);
+
+                // see if we need to keep searching for this
+                if (tempIndex == -1) {
+                    noMoreMatchesForReplIndex[i] = true;
+                } else {
+                    if (textIndex == -1 || tempIndex < textIndex) {
+                        textIndex = tempIndex;
+                        replaceIndex = i;
+                    }
+                }
+            }
+            // NOTE: logic duplicated above END
+
+        }
+        int textLength = text.length();
+        for (int i = start; i < textLength; i++) {
+            buf.append(text.charAt(i));
+        }
+        String result = buf.toString();
+
+        return result;
+    }
+}

--- a/src/java/org/jdbcdslog/MySqlRdbmsSpecifics.java
+++ b/src/java/org/jdbcdslog/MySqlRdbmsSpecifics.java
@@ -1,0 +1,46 @@
+package org.jdbcdslog;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * RDBMS specifics for the MySql DB.
+ *
+ * @author ShunLi
+ */
+public class MySqlRdbmsSpecifics implements RdbmsSpecifics {
+    public MySqlRdbmsSpecifics() {
+        super();
+    }
+
+    public String formatParameter(Object object) {
+        if (object == null) {
+            return "null";
+        } else if (object instanceof String) {
+            String text = LogUtils.replaceEach(
+                    (String) object,
+                    new String[] { "\\", "$", "'", "\"", "\r", "\n", "\t" },
+                    new String[] { "\\\\\\\\", "\\$", "\\\\'", "\\\\\"", "\\\\r", "\\\\n", "\\\\t" });
+
+            // handle Matcher's appendReplacement method special characters: \ and $
+            // handle mysql sql statment's special characters,like ' and " and \ and \r,\n,\t
+
+            // TODO only handle % and _ when use like statment. later processing.
+
+            return "'" + text + "'";
+        } else if (object instanceof Timestamp) {
+            return "'" + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(object) + "'";
+        } else if (object instanceof Time) {
+            return "'" + new SimpleDateFormat("HH:mm:ss").format(object) + "'";
+        } else if (object instanceof Date) {
+            return "'" + new SimpleDateFormat("yyyy-MM-dd").format(object) + "'";
+        } else if (object instanceof Boolean) {
+            return ((Boolean) object).booleanValue() ? "'1'" : "'0'";
+        } else {
+            return object.toString();
+        }
+    }
+
+}

--- a/src/java/org/jdbcdslog/OracleRdbmsSpecifics.java
+++ b/src/java/org/jdbcdslog/OracleRdbmsSpecifics.java
@@ -1,0 +1,42 @@
+package org.jdbcdslog;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * RDBMS specifics for the Oracle DB.
+ *
+ * @author ShunLi
+ */
+public class OracleRdbmsSpecifics implements RdbmsSpecifics {
+    public OracleRdbmsSpecifics() {
+        super();
+    }
+
+    public String formatParameter(Object object) {
+        if (object == null) {
+            return "null";
+        } else if (object instanceof String) {
+            String text = LogUtils.replaceEach(
+                    (String) object,
+                    new String[] { "\\", "$", "'", "&", "\r", "\n", "\t" },
+                    new String[] { "\\\\", "\\$", "''", "'||chr(38)||'", "", "'||chr(10)||'", "'||chr(9)||'" });
+
+            // handle Matcher's appendReplacement method special characters: \ and $
+            // handle Oracle sql statment's special characters,like ' and & and \r, \n,\t
+
+            // TODO only handle % and _ when use like statment. later processing.
+
+            return "'" + text + "'";
+        } else if (object instanceof Timestamp) {
+            return "to_timestamp('" + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(object) + "', 'yyyy-MM-dd hh24:mi:ss.ff3')";
+        } else if (object instanceof Date) {
+            return "to_date('" + new SimpleDateFormat("yyyy-MM-dd").format(object) + "', 'yyyy-MM-dd')";
+        } else if (object instanceof Boolean) {
+            return ((Boolean) object).booleanValue() ? "Y" : "N";
+        } else {
+            return object.toString();
+        }
+    }
+}

--- a/src/java/org/jdbcdslog/PooledConnectionLoggingProxy.java
+++ b/src/java/org/jdbcdslog/PooledConnectionLoggingProxy.java
@@ -1,0 +1,13 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.Proxy;
+
+import javax.sql.PooledConnection;
+
+public class PooledConnectionLoggingProxy {
+
+    public static PooledConnection wrap(PooledConnection con) {
+        return (PooledConnection) Proxy.newProxyInstance(con.getClass().getClassLoader(), new Class[] { PooledConnection.class }, new GenericLoggingHandler(con));
+    }
+
+}

--- a/src/java/org/jdbcdslog/PreparedStatementLoggingHandler.java
+++ b/src/java/org/jdbcdslog/PreparedStatementLoggingHandler.java
@@ -1,0 +1,65 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class PreparedStatementLoggingHandler implements InvocationHandler {
+    TreeMap parameters = new TreeMap();
+
+    Object target = null;
+
+    String sql = null;
+
+    static List setMethods = Arrays.asList(new String[] { "setAsciiStream", "setBigDecimal", "setBinaryStream", "setBoolean", "setByte", "setBytes", "setCharacterStream", "setDate", "setDouble", "setFloat", "setInt", "setLong", "setObject", "setShort", "setString", "setTime", "setTimestamp", "setURL" });
+
+    static List executeMethods = Arrays.asList(new String[] { "addBatch", "execute", "executeQuery", "executeUpdate" });
+
+    public PreparedStatementLoggingHandler(PreparedStatement ps, String sql) {
+        target = ps;
+        this.sql = sql;
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object r = null;
+        try {
+            long t1 = 0;
+            boolean toLog = (StatementLogger.isDebugEnabled() || SlowQueryLogger.isDebugEnabled()) && executeMethods.contains(method.getName());
+            if (toLog)
+                t1 = System.currentTimeMillis();
+            r = method.invoke(target, args);
+            if (setMethods.contains(method.getName()) && args[0] instanceof Integer)
+                parameters.put(args[0], args[1]);
+
+            if ("clearParameters".equals(method.getName()))
+                parameters = new TreeMap();
+
+            if (toLog) {
+                // StringBuffer sb = LogUtils.createLogEntry(method, sql, parametersToString(), null);
+                StringBuffer sb = LogUtils.createLogEntry(sql, parameters);
+
+                long t2 = System.currentTimeMillis();
+                long time = t2 - t1;
+                if (ConfigurationParameters.showTime) {
+                    sb.append(" ").append(t2 - t1).append(" ms.");
+                }
+
+                StatementLogger.debug(sb.toString());
+
+                if (time >= ConfigurationParameters.slowQueryThreshold) {
+                    SlowQueryLogger.debug(sb.toString());
+                }
+            }
+            if (r instanceof ResultSet)
+                r = ResultSetLoggingHandler.wrapByResultSetProxy((ResultSet) r);
+        } catch (Throwable t) {
+            LogUtils.handleException(t, StatementLogger.getLogger(), LogUtils.createLogEntry(sql, parameters));
+        }
+        return r;
+    }
+}

--- a/src/java/org/jdbcdslog/RdbmsSpecifics.java
+++ b/src/java/org/jdbcdslog/RdbmsSpecifics.java
@@ -1,0 +1,12 @@
+package org.jdbcdslog;
+
+/**
+ * Encapsulate sql formatting details about a particular relational database management system so that accurate, useable SQL can be composed for that RDMBS.
+ *
+ * @author ShunLi
+ */
+public interface RdbmsSpecifics {
+
+    String formatParameter(Object object);
+
+}

--- a/src/java/org/jdbcdslog/ResultSetLogger.java
+++ b/src/java/org/jdbcdslog/ResultSetLogger.java
@@ -1,0 +1,32 @@
+package org.jdbcdslog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResultSetLogger {
+    private static Logger logger = LoggerFactory.getLogger(ResultSetLogger.class);
+
+    public static void debug(String s) {
+        logger.debug(s + LogUtils.getStackTrace());
+    }
+
+    public static void info(String s) {
+        logger.info(s + LogUtils.getStackTrace());
+    }
+
+    public static boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    public static boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public static void error(String m, Throwable t) {
+        logger.error(m, t);
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/java/org/jdbcdslog/ResultSetLoggingHandler.java
+++ b/src/java/org/jdbcdslog/ResultSetLoggingHandler.java
@@ -1,0 +1,43 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+
+public class ResultSetLoggingHandler implements InvocationHandler {
+    Object target = null;
+
+    public ResultSetLoggingHandler(ResultSet target) {
+        this.target = target;
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object r = null;
+        try {
+            r = method.invoke(target, args);
+        } catch (Throwable e) {
+            LogUtils.handleException(e, ResultSetLogger.getLogger(), LogUtils.createLogEntry(method, null, null, null));
+        }
+        if (ResultSetLogger.isDebugEnabled() && method.getName().equals("next") && ((Boolean) r).booleanValue()) {
+            String fullMethodName = method.getDeclaringClass().getName() + "." + method.getName();
+            ResultSet rs = (ResultSet) target;
+            ResultSetMetaData md = rs.getMetaData();
+            StringBuffer s = new StringBuffer(fullMethodName).append(" {");
+            if (md.getColumnCount() > 0)
+                s.append(ConfigurationParameters.rdbmsSpecifics.formatParameter(rs.getObject(1)));
+            for (int i = 2; i <= md.getColumnCount(); i++)
+                s.append(", ").append(ConfigurationParameters.rdbmsSpecifics.formatParameter(rs.getObject(i)));
+            s.append("}");
+
+            ResultSetLogger.debug(s.toString());
+        }
+        return r;
+    }
+
+    static Object wrapByResultSetProxy(ResultSet r) {
+        return Proxy.newProxyInstance(r.getClass().getClassLoader(), new Class[] { ResultSet.class }, new ResultSetLoggingHandler(r));
+    }
+
+}

--- a/src/java/org/jdbcdslog/SlowQueryLogger.java
+++ b/src/java/org/jdbcdslog/SlowQueryLogger.java
@@ -1,0 +1,32 @@
+package org.jdbcdslog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SlowQueryLogger {
+    private static Logger logger = LoggerFactory.getLogger(SlowQueryLogger.class);
+
+    public static void debug(String s) {
+        logger.debug(s + LogUtils.getStackTrace());
+    }
+
+    public static void info(String s) {
+        logger.info(s + LogUtils.getStackTrace());
+    }
+
+    public static boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    public static boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public static void error(String m, Throwable t) {
+        logger.error(m, t);
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/java/org/jdbcdslog/SqlServerRdbmsSpecifics.java
+++ b/src/java/org/jdbcdslog/SqlServerRdbmsSpecifics.java
@@ -1,0 +1,44 @@
+package org.jdbcdslog;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * RDBMS specifics for the Sql Server DB.
+ *
+ * @author ShunLi
+ */
+public class SqlServerRdbmsSpecifics implements RdbmsSpecifics {
+    public SqlServerRdbmsSpecifics() {
+        super();
+    }
+
+    public String formatParameter(Object object) {
+        if (object == null) {
+            return "null";
+        } else if (object instanceof String) {
+            String text = LogUtils.replaceEach(
+                    (String) object,
+                    new String[] { "\\", "$", "'" },
+                    new String[] { "\\\\", "\\$", "''" });
+
+            // handle Matcher's appendReplacement method special characters: \ and $
+            // handle sql server sql statment's special characters,like '
+
+            // TODO handle other special characters which i don't know.
+            // TODO it has not enought actual test,maybe has some issues,if you use it,please help check it is ok? Thanks.
+            // TODO only handle % and _ when use like statment. later processing.
+
+            return "'" + text + "'";
+        } else if (object instanceof Timestamp) {
+            return "'" + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(object) + "'";
+        } else if (object instanceof Date) {
+            return "'" + new SimpleDateFormat("yyyy-MM-dd").format(object) + "'";
+        } else if (object instanceof Boolean) {
+            return ((Boolean) object).booleanValue() ? "'1'" : "'0'";
+        } else {
+            return object.toString();
+        }
+    }
+}

--- a/src/java/org/jdbcdslog/StatementLogger.java
+++ b/src/java/org/jdbcdslog/StatementLogger.java
@@ -1,0 +1,32 @@
+package org.jdbcdslog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StatementLogger {
+    private static Logger logger = LoggerFactory.getLogger(StatementLogger.class);
+
+    public static void debug(String s) {
+        logger.debug(s + LogUtils.getStackTrace());
+    }
+
+    public static void info(String s) {
+        logger.info(s + LogUtils.getStackTrace());
+    }
+
+    public static boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    public static boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    public static void error(String m, Throwable t) {
+        logger.error(m, t);
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/java/org/jdbcdslog/StatementLoggingHandler.java
+++ b/src/java/org/jdbcdslog/StatementLoggingHandler.java
@@ -1,0 +1,52 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+public class StatementLoggingHandler implements InvocationHandler {
+    Object targetStatement = null;
+
+    @SuppressWarnings("rawtypes")
+    static List executeMethods = Arrays.asList(new String[] { "addBatch", "execute", "executeQuery", "executeUpdate" });
+
+    public StatementLoggingHandler(Statement statement) {
+        targetStatement = statement;
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Object r = null;
+        try {
+            boolean toLog = (StatementLogger.isDebugEnabled() || SlowQueryLogger.isDebugEnabled()) && executeMethods.contains(method.getName());
+            long t1 = 0;
+            if (toLog)
+                t1 = System.currentTimeMillis();
+            r = method.invoke(targetStatement, args);
+            if (r instanceof ResultSet)
+                r = ResultSetLoggingHandler.wrapByResultSetProxy((ResultSet) r);
+            if (toLog) {
+                long t2 = System.currentTimeMillis();
+                StringBuffer sb = LogUtils.createLogEntry(method, args == null ? null : args[0].toString(), null, null);
+                long time = t2 - t1;
+
+                if (ConfigurationParameters.showTime) {
+                    sb.append(" ").append(t2 - t1).append(" ms.");
+                }
+
+                StatementLogger.debug(sb.toString());
+
+                if (time >= ConfigurationParameters.slowQueryThreshold) {
+                    SlowQueryLogger.debug(sb.toString());
+                }
+
+            }
+        } catch (Throwable t) {
+            LogUtils.handleException(t, StatementLogger.getLogger(), LogUtils.createLogEntry(method, args[0].toString(), null, null));
+        }
+        return r;
+    }
+
+}

--- a/src/java/org/jdbcdslog/XAConnectionLoggingProxy.java
+++ b/src/java/org/jdbcdslog/XAConnectionLoggingProxy.java
@@ -1,0 +1,13 @@
+package org.jdbcdslog;
+
+import java.lang.reflect.Proxy;
+
+import javax.sql.XAConnection;
+
+public class XAConnectionLoggingProxy {
+
+    public static XAConnection wrap(XAConnection con) {
+        return (XAConnection) Proxy.newProxyInstance(con.getClass().getClassLoader(), new Class[] { XAConnection.class }, new GenericLoggingHandler(con));
+    }
+
+}

--- a/src/java/org/jdbcdslog/XADataSourceProxy.java
+++ b/src/java/org/jdbcdslog/XADataSourceProxy.java
@@ -1,0 +1,23 @@
+package org.jdbcdslog;
+
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+public class XADataSourceProxy extends DataSourceProxyBase implements XADataSource, DataSource {
+
+    private static final long serialVersionUID = -2923593005281631348L;
+
+    public XADataSourceProxy() throws JDBCDSLogException {
+        super();
+    }
+
+    public Logger getParentLogger() {
+        return null;
+    }
+
+    public Object unwrap(Class targetClass) {
+        return null;
+    }
+
+}

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -2,13 +2,8 @@
   (:require [clojure.test :refer :all]
             [clojure.walk :refer [keywordize-keys]]
             [clojure.java.jdbc :as jdbc]
-            [puppetlabs.jdbc-util.core :refer :all]))
-
-(def test-db {:classname "org.postgresql.Driver"
-              :subprotocol "postgresql"
-              :subname (or (System/getenv "TEST_DBSUBNAME") "jdbc_util_test")
-              :user (or (System/getenv "TEST_DBUSER") "jdbc_util_test")
-              :password (or (System/getenv "TEST_DBPASS") "foobar")})
+            [puppetlabs.jdbc-util.core :refer :all]
+            [puppetlabs.jdbc-util.testutils :refer [test-db]]))
 
 (defn setup-db [db]
   (jdbc/execute! db ["CREATE TABLE authors (

--- a/test/puppetlabs/jdbc_util/cp_test.clj
+++ b/test/puppetlabs/jdbc_util/cp_test.clj
@@ -1,0 +1,34 @@
+(ns puppetlabs.jdbc-util.cp-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.jdbc :as jdbc]
+            [puppetlabs.jdbc-util.cp :refer :all]
+            [puppetlabs.jdbc-util.testutils :refer [test-db]]
+            [puppetlabs.trapperkeeper.testutils.logging :as logging]))
+
+(deftest connection
+  (testing "test that the connection pool works"
+    (logging/with-test-logging
+      (let [db (pooled-db-spec "jdbc-util-test" test-db)]
+        (close-pooled-db-spec db)))))
+
+(deftest operations
+  (testing "test basic jdbc operations work"
+    (logging/with-test-logging
+      (let [db (pooled-db-spec "jdbc-util-test" test-db)]
+        (= (jdbc/query db "select 1 as foo")
+           {:foo 1})
+        (close-pooled-db-spec db)))))
+
+(deftest transactions
+  (testing "test changing transaction level"
+    (logging/with-test-logging
+      (let [db (pooled-db-spec "jdbc-util-test" test-db)]
+        (jdbc/with-db-transaction [t db :isolation :serializable]
+          (= (jdbc/query db "select 1 as foo")
+             {:foo 1}))
+
+        (jdbc/with-db-transaction [t db :isolation :read-committed]
+          (= (jdbc/query db "select 1 as foo")
+             {:foo 1}))
+
+        (close-pooled-db-spec db)))))

--- a/test/puppetlabs/jdbc_util/testutils.clj
+++ b/test/puppetlabs/jdbc_util/testutils.clj
@@ -1,0 +1,7 @@
+(ns puppetlabs.jdbc-util.testutils)
+
+(def test-db {:classname "org.postgresql.Driver"
+              :subprotocol "postgresql"
+              :subname (or (System/getenv "TEST_DBSUBNAME") "jdbc_util_test")
+              :user (or (System/getenv "TEST_DBUSER") "jdbc_util_test")
+              :password (or (System/getenv "TEST_DBPASS") "foobar")})


### PR DESCRIPTION
(work in progress, please don't merge)

I'm raising this early as I'm going to work on some other PDB release-related tickets this sprint, and wanted to
get something up there to look at.

This is a work-in-progress attempt at getting HikariCP connection pooling + jdbcdslog-exp +
some earlier metrics working going. I'll try to annotate where the dodgy parts are.

In particular you can see the fork of jdbcdslog-exp introduced here, this is for a few reasons:

* That older code is no longer maintained, last touched 2011
* The old code doesn't log to debug, this fork does
* There is an absence of obvious things, like an inability to retrieve the proxied object so you can call close() on it, which is useful for testing at the very least

I'm still not convinced forking is the right idea, however I have high hopes for this newer fork
I found here: https://github.com/adrianshum/jdbcdslog, however it suffers all the same problems
as before except for still being maintained. Perhaps the better direction is to patch upstream, however
there is one remaining element that related to per pool configuration, as opposed to the global
nature of configuration in jdbcdslog today.

Anyway ... the logging does work even though it looks horrid to fork all this code.

I'll leave other annotations throughout the code where applicable.

Signed-off-by: Ken Barber <ken@bob.sh>