### PR TITLE
(maint) Add a one-second timeout to `db-up?`

### DIFF
--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -58,6 +58,10 @@
 
     (testing "returns false if the arithmetic doesn't check out"
       (with-redefs [jdbc/query (fn [_ _] [{:answer 49}])]
+        (is (false? (db-up? nil)))))
+
+    (testing "returns false if the check times out"
+      (with-redefs [jdbc/query (fn [_ _] (Thread/sleep 2000) [{:answer 42}])]
         (is (false? (db-up? nil)))))))
 
 (deftest ^:database querying


### PR DESCRIPTION
Previously, the db-up? function could potentially hang indefinitely, which is never what we want. This change gives the function one second to connect, returning false if it fails to do so in that time.