### PR TITLE
(maint) There can be only one test DB config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_script:
   - psql -c 'create database jdbc_util_test;' -U postgres
 env:
   global:
-    - TEST_DBUSER=postgres
-    - TEST_DBPASS=
-    - TEST_DBSUBNAME=//127.0.0.1:5432/jdbc_util_test
+    - JDBCUTIL_DBNAME=//127.0.0.1:5432/jdbc_util_test
+    - JDBCUTIL_DBUSER=postgres
+    - JDBCUTIL_DBPASS=
 addons:
   postgresql: "9.3"
 notifications:

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -4,11 +4,12 @@
             [clojure.java.jdbc :as jdbc]
             [puppetlabs.jdbc-util.core :refer :all]))
 
-(def test-db {:classname "org.postgresql.Driver"
-              :subprotocol "postgresql"
-              :subname (or (System/getenv "TEST_DBSUBNAME") "jdbc_util_test")
-              :user (or (System/getenv "TEST_DBUSER") "jdbc_util_test")
-              :password (or (System/getenv "TEST_DBPASS") "foobar")})
+(def test-db
+  {:classname "org.postgresql.Driver"
+   :subprotocol "postgresql"
+   :subname (or (System/getenv "JDBCUTIL_DBNAME") "jdbc_util_test")
+   :user (or (System/getenv "JDBCUTIL_DBUSER") "jdbc_util_test")
+   :password (or (System/getenv "JDBCUTIL_DBPASS") "foobar")})
 
 (defn setup-db [db]
   (jdbc/execute! db ["CREATE TABLE authors (
@@ -33,13 +34,7 @@
 
 (use-fixtures :once
               (fn [f]
-                (let [env     #(System/getenv %)
-                      test-db (if (env "JDBCUTIL_DBNAME")
-                                (merge test-db
-                                       {:subname (env "JDBCUTIL_DBNAME")
-                                        :user (env "JDBCUTIL_DBUSER")
-                                        :password (env "JDBCUTIL_PASS")})
-                                test-db)]
+                (let [env #(System/getenv %)]
                   (drop-public-tables! test-db)
                   (setup-db test-db)
                   (f))))


### PR DESCRIPTION
Remove the modification of the test-db config performed in the fixture
that resets the test db, since it's confusing & error-prone to modify
the DB config with environment variable values in two different places,
and isn't necessary.

Change the name of the environment variables used to set the DB
configuration to `JDBCUTIL_DB*`, where `*` is one of `NAME`, `USER`, or
`PASS`. This is consistent with the convention our other projects have in
naming these environment variables.