### PR TITLE
(PE-9468) Add shared `connection-pool` function.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
+  :pedantic :abort
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.2"]
                  [org.postgresql/postgresql "9.3-1100-jdbc41"]
@@ -21,5 +22,4 @@
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password
-                                     :sign-releases false}]]
-)
+                                     :sign-releases false}]])

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.2"]
                  [org.postgresql/postgresql "9.3-1100-jdbc41"]
-                 [com.jolbox/bonecp "0.8.0.RELEASE" :exclusions [[org.slf4j/slf4j-api]]]
+                 [com.jolbox/bonecp "0.8.0.RELEASE"]
                  [puppetlabs/kitchensink ~ks-version]]
 
   :plugins [[lein-release "1.0.5"]]

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -59,6 +59,11 @@
       (with-redefs [jdbc/query (fn [_ _] (Thread/sleep 2000) [{:answer 42}])]
         (is (false? (db-up? nil)))))))
 
+(deftest connection-pool-test
+  (testing "connection-pool returns a usable DB spec"
+    (let [pooled-db (connection-pool test-db)]
+      (is (db-up? pooled-db)))))
+
 (deftest ^:database querying
   (testing "works within a transaction"
     (let [rows (jdbc/with-db-transaction [test-db test-db]


### PR DESCRIPTION
Add the `connection-pool` function to the core namespace, which takes
a DB spec defined using the :subprotocol, :subname, :user, and :password
keys and turns it into a DB spec with just a :datasource key, whose
value is a pooled DataSource object.