### PR TITLE
(PE-9470) Add connection retrying via HikariCP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: clojure
 lein: lein2
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
 script: lein2 test :all

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.2"]
                  [org.postgresql/postgresql "9.3-1100-jdbc41"]
-                 [com.jolbox/bonecp "0.8.0.RELEASE"]
+                 [com.zaxxer/HikariCP-java6 "2.3.9"]
                  [puppetlabs/kitchensink ~ks-version]]
 
   :plugins [[lein-release "1.0.5"]]

--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.jdbc-util.core
-  (:import com.jolbox.bonecp.BoneCPDataSource
+  (:import [com.zaxxer.hikari HikariDataSource]
            java.util.regex.Pattern)
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
@@ -10,14 +10,17 @@
   keys, return a pooled DB spec map (one containing just the :datasource key
   with a pooled DataSource object as the value). The returned pooled DB spec
   can be passed directly as the first argument to clojure.java.jdbc's
-  functions."
+  functions.
+
+  Times out after 30 seconds and throws org.postgresql.util.PSQLException"
   [db-spec]
-  (let [ds (doto (BoneCPDataSource.)
+  (let [ds (doto (HikariDataSource.)
              (.setJdbcUrl (str "jdbc:"
                                (:subprotocol db-spec) ":"
                                (:subname db-spec)))
              (.setUsername (:user db-spec))
-             (.setPassword (:password db-spec)))]
+             (.setPassword (:password db-spec))
+             (.setInitializationFailFast false))]
     {:datasource ds}))
 
 (defmacro with-timeout [timeout-s default & body]


### PR DESCRIPTION
Switch from BoneCP to HikariCP to take advantage of the latter's built-in connection retrying. This commit leaves HikariCP's default 30 second timeout for failed connections.

*NB*: the test adds about 30 seconds to each test run, which kind of sucks. I'm not sure if there's a better way, but I'm more than open to suggestions.