### PR TITLE
(maint) add debug logging for test failures

### DIFF
--- a/dev-resources/log4j.properties
+++ b/dev-resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, console
+log4j.logger.puppetlabs.jdbc-util.core=DEBUG
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p %c: %m%n

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,9 @@
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]]
 
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-simple "1.7.12"]]}}
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.21"]
+                                  [org.slf4j/slf4j-log4j12 "1.7.21"]
+                                  [log4j/log4j "1.2.17"]]}}
 
   :plugins [[lein-release "1.0.5"]]
 

--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -3,6 +3,7 @@
            java.util.regex.Pattern)
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as ks]))
 
 (defn connection-pool
@@ -35,7 +36,8 @@
     (try (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
                [{:keys [answer]}] (jdbc/query db-spec [select-42])]
            (= answer 42))
-         (catch Exception _
+         (catch Exception e
+           (log/debug e "db-up? failed")
            false))))
 
 (defn public-tables


### PR DESCRIPTION
This adds debug logging to the db-up? function, which is failing in acceptance tests.
In addition, it enables debug log output for the puppetlabs.jdbc-util.core namespace when the tests are running.