### PR TITLE
(PE-15268) Improve logging for db-up? failure

### DIFF
--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -56,7 +56,7 @@
         (is (false? (db-up? nil)))))
 
     (testing "returns false if the check times out"
-      (with-redefs [jdbc/query (fn [_ _] (Thread/sleep 2000) [{:answer 42}])]
+      (with-redefs [jdbc/query (fn [_ _] (Thread/sleep 5000) [{:answer 42}])]
         (is (false? (db-up? nil)))))))
 
 (deftest connection-pool-test


### PR DESCRIPTION
Log at a useful level and with a more verbose message when this fails or times
out. Since this is in the service status check failures should be seen by the
user.