### PR TITLE
(PE-15534) Query converts PGObjects to their vals.

### DIFF
--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -63,10 +63,10 @@
   ([result-set]
    (convert-result-arrays vec result-set))
   ([f result-set]
-   (let [convert #(cond
-                    (ks/array? %) (f %)
-                    (isa? (class %) java.sql.Array) (f (.getArray %))
-                    :else %)]
+   (let [convert (fn [v] (cond
+                           (ks/array? v) (f v)
+                           (instance? java.sql.Array v) (f (.getArray v))
+                           :else v))]
      (map #(ks/mapvals convert %) result-set))))
 
 (defn query


### PR DESCRIPTION
Add the `convert-result-pgobjects` function, which converts all
PGobjects to whatever their getValue method returns.

Change `query` to use the above function.

Add a test that ensures that a UUID value retrieved from the database is
converted to a java.util.UUID by way of `convert-result-pgobjects`.