### PR TITLE
(PE-14381) Add pglogical utility functions

### DIFF
--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -156,3 +156,31 @@
                        [sql 0]
                        seq-params-w-indices)]
     (vec (conj (flatten parameters) sql'))))
+
+(defn has-extension [db extension]
+  (-> (jdbc/query db ["select count(*) from pg_extension where extname = ?" extension])
+      first
+      :count
+      pos?))
+
+(defn has-pglogical-extension [db]
+  (has-extension db "pglogical"))
+
+(defn- unsafe-escape-sql-string
+  "Escape the given string so it can be \"safely\" passed as a string parameter
+  to an sql query."
+  [s]
+  (clojure.string/replace s "'" "''"))
+
+(defn wrap-ddl-for-pglogical
+  "Wrap the given sql (presumably DDL) in a call to
+  pglogical.replicate_ddl_command, escaping quotes and wrapping the statement so
+  it won't return anything."
+  [sql schema]
+  (str "do 'begin perform "
+       (unsafe-escape-sql-string
+        (str "pglogical.replicate_ddl_command('"
+             "set local search_path to " schema "; "
+             (unsafe-escape-sql-string sql)
+             "');"))
+       " end;';"))

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -221,3 +221,17 @@
               "2.0.0"
               ["doohickey" "jobby" "thingie"]
               ["US Robotics" "Omnicorp" "Cyberdyne Systems" "Morgan Industries"]])))))
+
+(deftest has-extension-test
+  (testing "look for db extension that exists"
+    (is (has-extension test-db "plpgsql")))
+
+  (testing "look for db extension that does not exist"
+    (is (not (has-extension test-db "notanextension")))))
+
+(deftest wrap-ddl-for-pglogical-test
+  (is (= (str "do 'begin perform"
+              " pglogical.replicate_ddl_command(''set local search_path to public;"
+              " create table test(a integer);''"
+              "); end;';")
+         (wrap-ddl-for-pglogical "create table test(a integer);" "public"))))

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -224,10 +224,10 @@
 
 (deftest has-extension-test
   (testing "look for db extension that exists"
-    (is (has-extension test-db "plpgsql")))
+    (is (has-extension? test-db "plpgsql")))
 
   (testing "look for db extension that does not exist"
-    (is (not (has-extension test-db "notanextension")))))
+    (is (not (has-extension? test-db "notanextension")))))
 
 (deftest wrap-ddl-for-pglogical-test
   (is (= (str "do 'begin perform"


### PR DESCRIPTION
Add has-extension, has-pglogical-extension, and wrap-ddl-for-pglogical.
These will be used by console-services projects to correctly execute
DDL when pglogical is installed.