### PR TITLE
(maint) Catch perm error in replication set update

### DIFF
--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -1,4 +1,5 @@
 (ns puppetlabs.jdbc-util.pglogical
+  (:import [org.postgresql.util PSQLException PSQLState])
   (:require [clojure.java.jdbc :as jdbc]
             [puppetlabs.jdbc-util.core :refer [has-extension?]]))
 
@@ -25,12 +26,22 @@
        " end;';"))
 
 (defn update-pglogical-replication-set
-  "Update the default pglogical replication set to replicate all tables in the
-  given schema."
+  "Tries to update the default pglogical replication set to replicate all tables
+  in the given schema. If the db user don't have rights to update pglogical,
+  catches the exception and returns false. Other exceptions are passed through.
+  Returns true if the replication set was successfully updated."
   [db schema]
-  (jdbc/query db
-              (str "select pglogical.replication_set_add_all_tables("
-                   "'default',"
-                   "'{\"" schema "\"}',"
-                   "true"
-                   ");")))
+  (try
+    (jdbc/query db
+                (str "select pglogical.replication_set_add_all_tables("
+                     "'default',"
+                     "'{\"" schema "\"}',"
+                     "true"
+                     ");"))
+    true
+    (catch PSQLException e
+      (if (= "42501" (.getSQLState e))
+        false
+        (throw e)))))
+
+


### PR DESCRIPTION
Changes exception behavior of update-pglogical-replication-set. If the
db user don't have rights to update pglogical, catches the exception and
returns false. Other exceptions are passed through.

This fixes db migration crashes in users of this function when pglogical
is installed but the database is read-only.