### PR TITLE
(PE-16150) Support init-datasource parameter for pools

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.jdbc_util \n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
-"POT-Creation-Date: 2016-05-27 11:42:25\n"
+"POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,22 +32,28 @@ msgid_plural "There are not {0} '?'s in the given string"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/puppetlabs/jdbc_util/middleware.clj:17
+msgid ""
+"The operation could not be performed because of insufficient database "
+"permissions."
+msgstr ""
+
 #: src/puppetlabs/jdbc_util/pool.clj:29
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:74
+#: src/puppetlabs/jdbc_util/pool.clj:80
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:77
+#: src/puppetlabs/jdbc_util/pool.clj:83
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:85 src/puppetlabs/jdbc_util/pool.clj:88
+#: src/puppetlabs/jdbc_util/pool.clj:91 src/puppetlabs/jdbc_util/pool.clj:94
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:108
+#: src/puppetlabs/jdbc_util/pool.clj:114
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -73,67 +73,69 @@
 (defn wrap-with-delayed-init
   "Wraps a connection pool that loops trying to get a connection, and then runs
   init-fn (with the connection as argument) before returning any connections to
-  the application. Accepts a timeout in ms that's used when deferencing the
+  the application. Accepts a timeout in ms that's used when dereferencing the
   future and by the status check. The datasource should have
   initialization-fail-fast set before being created or this is pointless."
-  [^HikariDataSource datasource init-fn timeout]
-  (when-not (.getHealthCheckRegistry datasource)
-    (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
-  (let [init-error (atom nil)
-        pool-future
-        (future
-          (loop []
-            (if-let [result
-                     (try
-                       ;; Try to get a connection to make sure the db is ready
-                       (.close (.getConnection datasource))
-                       (try (init-fn {:datasource datasource})
-                            (catch Exception e
-                              (swap! init-error (constantly e))
-                              (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName datasource)))))
-                       datasource
-                       (catch SQLTransientException e
-                         (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
-                         nil))]
-              result
-              (recur))))]
-    (reify
-      DataSource
-      (getConnection [this]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
-      (getConnection [this username password]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
-                        username
-                        password))
+  ([^HikariDataSource datasource init-fn timeout]
+   (wrap-with-delayed-init datasource init-fn datasource timeout))
+  ([^HikariDataSource datasource init-fn init-datasource timeout]
+   (when-not (.getHealthCheckRegistry datasource)
+     (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
+   (let [init-error (atom nil)
+         pool-future
+         (future
+           (loop []
+             (if-let [result
+                      (try
+                          ;; Try to get a connection to make sure the db is ready
+                          (.close (.getConnection datasource))
+                        (try (init-fn {:datasource init-datasource})
+                          (catch Exception e
+                            (swap! init-error (constantly e))
+                            (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName init-datasource)))))
+                        datasource
+                        (catch SQLTransientException e
+                          (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
+                          nil))]
+               result
+               (recur))))]
+     (reify
+       DataSource
+       (getConnection [this]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
+       (getConnection [this username password]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
+                         username
+                         password))
 
-      Closeable
-      (close [this]
-        (.close datasource))
+       Closeable
+       (close [this]
+         (.close datasource))
 
-      PoolStatus
-      (status [this]
-        (if (realized? pool-future)
-          (let [connectivity-check (str (.getPoolName datasource)
-                                        ".pool.ConnectivityCheck")
-                health-result (.runHealthCheck
-                               (.getHealthCheckRegistry datasource)
-                               connectivity-check)
-                healthy? (and (.isHealthy health-result)
-                              (nil? @init-error))
-                messages (remove nil? [(some->> @init-error
-                                                (.getMessage)
-                                                (tru "Initialization resulted in an error: {0}"))
-                                       (.getMessage health-result)])]
-            (cond-> {:state (if healthy?
-                              :ready
-                              :error)}
-              (not healthy?) (merge {:messages messages})))
-          {:state :starting}))
+       PoolStatus
+       (status [this]
+         (if (realized? pool-future)
+           (let [connectivity-check (str (.getPoolName datasource)
+                                         ".pool.ConnectivityCheck")
+                 health-result (.runHealthCheck
+                                (.getHealthCheckRegistry datasource)
+                                connectivity-check)
+                 healthy? (and (.isHealthy health-result)
+                               (nil? @init-error))
+                 messages (remove nil? [(some->> @init-error
+                                                 (.getMessage)
+                                                 (tru "Initialization resulted in an error: {0}"))
+                                        (.getMessage health-result)])]
+             (cond-> {:state (if healthy?
+                               :ready
+                               :error)}
+               (not healthy?) (merge {:messages messages})))
+           {:state :starting}))
 
-      (init-error [this]
-        @init-error))))
+       (init-error [this]
+         @init-error)))))
 
 (defn connection-pool-with-delayed-init
   "Create a connection pool that loops trying to get a connection, and then runs
@@ -141,6 +143,11 @@
   the application. Accepts a timeout in ms that's used when deferencing the
   future. This overrides the value of initialization-fail-fast and always sets
   it to false. "
-  [^HikariConfig config init-fn timeout]
-  (.setInitializationFailFast config false)
-  (wrap-with-delayed-init (HikariDataSource. config) init-fn timeout))
+  ([^HikariConfig config init-fn timeout]
+   (connection-pool-with-delayed-init config init-fn nil timeout))
+  ([^HikariConfig config init-fn init-datasource timeout]
+   (let [datasource (HikariDataSource. config)]
+     (.setInitializationFailFast config false)
+     (if init-datasource
+       (wrap-with-delayed-init datasource init-fn init-datasource timeout)
+       (wrap-with-delayed-init datasource init-fn timeout)))))


### PR DESCRIPTION
In case where the init function needs to be run with separate credentials, the new optional `init-datasource` parameter can be supplied.