### PR TITLE
(PE-14580) pglogical status fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ To file a bug, please open a Jira ticket against this project. Bugs and PRs are
 addressed on a best-effort basis. Puppet Inc. does not guarantee support for
 this project.
 
-## Maintainenance
+## Running tests
+You'll need PostgreSQL installed (9.4 is the mainly-used version for us right
+now), and set up a "jdbc_util_test" DB and user with password "foobar".
+
+## Maintenance
 Maintainers: Steve Axthelm <steve@puppet.com>
 Tickets: [Puppet Enterprise](https://tickets.puppetlabs.com/browse/ENTERPRISE/). Make sure to set component to "jdbc-util".
 

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,8 @@
             [org.clojure/clojure "1.8.0"]
             [puppetlabs/i18n "0.4.0"]]
 
+  :jar-exclusions [#"\.sw[a-z]$" #"~$" #"logback\.xml$" #"log4j\.properties$"]
+
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}
 

--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.jdbc-util.pglogical
   (:import [org.postgresql.util PSQLException PSQLState])
   (:require [clojure.java.jdbc :as jdbc]
+            [puppetlabs.i18n.core :refer [tru]]
             [puppetlabs.jdbc-util.core :refer [has-extension?]]))
 
 (defn has-pglogical-extension? [db]
@@ -44,4 +45,96 @@
         false
         (throw e)))))
 
+;;;; Status
 
+(def create-status-alias
+  "CREATE OR REPLACE FUNCTION show_subscription_status(OUT subscription_name text, OUT status text,
+     OUT provider_node text, OUT provider_dsn text, OUT slot_name text, OUT replication_sets text[],
+     OUT forward_origins text[])
+     RETURNS SETOF record AS $$
+       SELECT * FROM pglogical.show_subscription_status();
+     $$ LANGUAGE SQL
+     SECURITY DEFINER;")
+
+(defn add-status-alias
+  "Adds an alias for the pglogical show_subscription_status function, allowing
+  it to be called by any user, not just admin."
+  [db]
+  (jdbc/execute! db [create-status-alias]))
+
+(defn consolidate-replication-status
+  "Given a list of states of pglogical subscriptions, returns
+  the status of data replication. Returns :running if all subscriptions for
+  that database are up and running, :disabled if any subscription has been
+  turned off, :down if any connection has been severed (overrides :disabled),
+  :none if pglogical replication is not configured, or :unknown. Note that
+  :down may not be returned for some time or at all, depending on your
+  postgresql TCP settings."
+  [statuses]
+  (let [all-good? #(every? (partial = "replicating") %)
+        disabled? #(some (partial = "disabled") %)
+        down? #(some (partial = "down") %)]
+    (cond
+      (empty? statuses) :none
+      (all-good? statuses) :running
+      (down? statuses) :down
+      (disabled? statuses) :disabled
+      :else :unknown)))
+
+(defn replica-replication-status
+  "Given a DB connection for a pglogical replica node, returns
+  the status of data replication. Returns :running if all subscriptions for
+  that database are up and running, :disabled if any subscription has been
+  disabled, :down if any connection has been severed (overrides :disabled),
+  :none if pglogical replication is not configured, else :unknown. Note that
+  :down may not be returned for some time or at all, depending on your
+  postgresql TCP settings."
+  [db]
+  (if (has-pglogical-extension? db)
+    (-> (jdbc/query db ["SELECT status from show_subscription_status()"] {:row-fn :status})
+        (consolidate-replication-status))
+    :none))
+
+(defn consolidate-provider-status
+  [statuses]
+  (let [all-active? #(every? true? %)]
+    (case
+      (empty? statuses) :none
+      (all-active? statuses) :active
+      :else :inactive)))
+
+(defn provider-replication-status
+  "Given a DB connection for a pglogical provider node, query whether the
+  node's subscription is currently active or not. Returns :active or
+  :inactive, or :none if pglogical is not installed."
+  [db]
+  (if (has-pglogical-extension? db)
+    (jdbc/query db ["SELECT active FROM pg_replication_slots WHERE database = ?" (:db db)])
+    :none))
+
+(defn replication-status
+  "Given a DB connection for a pglogical node and the role of that node,
+  :source or :replica, query replication status. Returns a map reporting the
+  role and its status. Valid status values vary depending on the role; see
+  other replication-status functions for more information."
+  [db role]
+  (let [status (if (= :source role)
+                 (provider-replication status db)
+                 (replica-replication-status db))]
+    {:role role
+     :status status}))
+
+(defn replication-alert
+  "Produces an alert that can be used if replication is down. This is only a
+  function for localization reasons.
+
+  This function takes a service name and a replication state, which can be one
+  of: :disabled, :down, or :unknown. It then returns a human-readable message."
+  [service-name replication-state]
+  (let [construct-error (fn [message] {:severity "error"
+                                       :message message})]
+
+  (case replication-state
+    :down (construct-error (tru "Database replication for {0} is currently down." service-name))
+    :disabled (construct-error (tru "Database replication for {0} has been disabled." service-name))
+    :unknown (construct-error (tru "Database replication for {0} is in an unknown state.")))))

--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -8,3 +8,18 @@
               " create table test(a integer);''"
               "); end;';")
          (wrap-ddl-for-pglogical "create table test(a integer);" "public"))))
+
+(deftest consolidate-replication-status-test
+  (testing "when 2 subscriptions are running, returns :running"
+    (is (= :running (consolidate-replication-status ["replicating" "replicating"]))))
+  (testing "when one subscription is down,"
+    (testing "and the rest are running, returns :down"
+      (is (= :down (consolidate-replication-status ["replicating" "down"]))))
+    (testing "and another is disabled, returns :down"
+      (is (= :down (consolidate-replication-status ["disabled" "down"])))))
+  (testing "when one subscription is disabled,"
+    (testing "and the rest are running, returns :disabled"
+      (is (= :disabled (consolidate-replication-status ["replicating" "disabled"])))))
+  (testing "when no subscriptions are configured, returns :disabled"
+    (testing "and the rest are running, returns :none"
+      (is (= :none (consolidate-replication-status []))))))


### PR DESCRIPTION
Add a set of functions that projects can share to query pglogical replication state. Designed for use with trapperkeeper-status.