### PR TITLE
(PE-16150) Support init-datasource parameter for pools

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -38,22 +38,26 @@ msgid ""
 "permissions."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:29
+#: src/puppetlabs/jdbc_util/pool.clj:36
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:80
+#: src/puppetlabs/jdbc_util/pool.clj:96
+msgid "{0} - An error was encountered during database migration."
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:102
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:83
+#: src/puppetlabs/jdbc_util/pool.clj:106
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:91 src/puppetlabs/jdbc_util/pool.clj:94
+#: src/puppetlabs/jdbc_util/pool.clj:115 src/puppetlabs/jdbc_util/pool.clj:118
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:114
+#: src/puppetlabs/jdbc_util/pool.clj:138
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.jdbc_util \n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
-"POT-Creation-Date: 2016-05-27 11:42:25\n"
+"POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,22 +32,28 @@ msgid_plural "There are not {0} '?'s in the given string"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/puppetlabs/jdbc_util/middleware.clj:17
+msgid ""
+"The operation could not be performed because of insufficient database "
+"permissions."
+msgstr ""
+
 #: src/puppetlabs/jdbc_util/pool.clj:29
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:74
+#: src/puppetlabs/jdbc_util/pool.clj:80
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:77
+#: src/puppetlabs/jdbc_util/pool.clj:83
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:85 src/puppetlabs/jdbc_util/pool.clj:88
+#: src/puppetlabs/jdbc_util/pool.clj:91 src/puppetlabs/jdbc_util/pool.clj:94
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:108
+#: src/puppetlabs/jdbc_util/pool.clj:114
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.6.1"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
+                 [migratus "0.8.28"]
                  [com.zaxxer/HikariCP "2.4.3"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n "0.4.0"]

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -1,0 +1,57 @@
+(ns puppetlabs.jdbc-util.migration
+  (:import java.sql.BatchUpdateException)
+  (:require [migratus.core :as migratus]
+            [migratus.protocols :as mproto]
+            [puppetlabs.jdbc-util.pglogical :as pglogical]))
+
+(defn spec->migration-db-spec
+  "Given a user defined database config, transform the config into a db-spec
+  appropriate for passing to migratus's migrate function."
+  [db-config]
+  (let [user (or (:migration-user db-config)
+                 (:user db-config))
+        password (or (:migration-password db-config)
+                     (:password db-config))]
+    (-> db-config
+        (assoc :user user
+               :password password)
+        (dissoc :migration-user
+                :migration-password))))
+
+(defn migrate
+  "Migrate 'db' using migratus with a given 'migration-dir'."
+  [db migration-dir]
+  (let [have-pglogical (pglogical/has-pglogical-extension? db)
+        pg-schema "public"]
+    (try
+      (migratus/migrate {:store :database
+                         :migration-dir migration-dir
+                         :db db
+                         :modify-sql-fn (if have-pglogical
+                                          #(pglogical/wrap-ddl-for-pglogical % pg-schema)
+                                          identity)})
+      (when have-pglogical
+        (pglogical/update-pglogical-replication-set db pg-schema))
+      (catch BatchUpdateException e
+        (let [root-e (last (seq e))]
+          (throw root-e))))))
+
+(defn migrate-until-just-before
+  "Like 'migrate' but only migrates up to the given
+  migration-id (non-inclusive)."
+  [db migration-dir migration-id]
+  (let [have-pglogical (pglogical/has-pglogical-extension? db)
+        pg-schema "public"]
+    (try
+      (migratus/migrate-until-just-before {:store :database
+                                           :migration-dir migration-dir
+                                           :db db
+                                           :modify-sql-fn (if have-pglogical
+                                                            #(pglogical/wrap-ddl-for-pglogical % pg-schema)
+                                                            identity)}
+                                          migration-id)
+      (when have-pglogical
+        (pglogical/update-pglogical-replication-set db pg-schema))
+      (catch BatchUpdateException e
+        (let [root-e (last (seq e))]
+          (throw root-e))))))

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -73,67 +73,69 @@
 (defn wrap-with-delayed-init
   "Wraps a connection pool that loops trying to get a connection, and then runs
   init-fn (with the connection as argument) before returning any connections to
-  the application. Accepts a timeout in ms that's used when deferencing the
+  the application. Accepts a timeout in ms that's used when dereferencing the
   future and by the status check. The datasource should have
   initialization-fail-fast set before being created or this is pointless."
-  [^HikariDataSource datasource init-fn timeout]
-  (when-not (.getHealthCheckRegistry datasource)
-    (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
-  (let [init-error (atom nil)
-        pool-future
-        (future
-          (loop []
-            (if-let [result
-                     (try
-                       ;; Try to get a connection to make sure the db is ready
-                       (.close (.getConnection datasource))
-                       (try (init-fn {:datasource datasource})
-                            (catch Exception e
-                              (swap! init-error (constantly e))
-                              (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName datasource)))))
-                       datasource
-                       (catch SQLTransientException e
-                         (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
-                         nil))]
-              result
-              (recur))))]
-    (reify
-      DataSource
-      (getConnection [this]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
-      (getConnection [this username password]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
-                        username
-                        password))
+  ([^HikariDataSource datasource init-fn timeout]
+   (wrap-with-delayed-init datasource init-fn datasource timeout))
+  ([^HikariDataSource datasource init-fn init-datasource timeout]
+   (when-not (.getHealthCheckRegistry datasource)
+     (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
+   (let [init-error (atom nil)
+         pool-future
+         (future
+           (loop []
+             (if-let [result
+                      (try
+                          ;; Try to get a connection to make sure the db is ready
+                          (.close (.getConnection datasource))
+                        (try (init-fn {:datasource init-datasource})
+                          (catch Exception e
+                            (swap! init-error (constantly e))
+                            (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName init-datasource)))))
+                        datasource
+                        (catch SQLTransientException e
+                          (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
+                          nil))]
+               result
+               (recur))))]
+     (reify
+       DataSource
+       (getConnection [this]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
+       (getConnection [this username password]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
+                         username
+                         password))
 
-      Closeable
-      (close [this]
-        (.close datasource))
+       Closeable
+       (close [this]
+         (.close datasource))
 
-      PoolStatus
-      (status [this]
-        (if (realized? pool-future)
-          (let [connectivity-check (str (.getPoolName datasource)
-                                        ".pool.ConnectivityCheck")
-                health-result (.runHealthCheck
-                               (.getHealthCheckRegistry datasource)
-                               connectivity-check)
-                healthy? (and (.isHealthy health-result)
-                              (nil? @init-error))
-                messages (remove nil? [(some->> @init-error
-                                                (.getMessage)
-                                                (tru "Initialization resulted in an error: {0}"))
-                                       (.getMessage health-result)])]
-            (cond-> {:state (if healthy?
-                              :ready
-                              :error)}
-              (not healthy?) (merge {:messages messages})))
-          {:state :starting}))
+       PoolStatus
+       (status [this]
+         (if (realized? pool-future)
+           (let [connectivity-check (str (.getPoolName datasource)
+                                         ".pool.ConnectivityCheck")
+                 health-result (.runHealthCheck
+                                (.getHealthCheckRegistry datasource)
+                                connectivity-check)
+                 healthy? (and (.isHealthy health-result)
+                               (nil? @init-error))
+                 messages (remove nil? [(some->> @init-error
+                                                 (.getMessage)
+                                                 (tru "Initialization resulted in an error: {0}"))
+                                        (.getMessage health-result)])]
+             (cond-> {:state (if healthy?
+                               :ready
+                               :error)}
+               (not healthy?) (merge {:messages messages})))
+           {:state :starting}))
 
-      (init-error [this]
-        @init-error))))
+       (init-error [this]
+         @init-error)))))
 
 (defn connection-pool-with-delayed-init
   "Create a connection pool that loops trying to get a connection, and then runs
@@ -141,6 +143,11 @@
   the application. Accepts a timeout in ms that's used when deferencing the
   future. This overrides the value of initialization-fail-fast and always sets
   it to false. "
-  [^HikariConfig config init-fn timeout]
-  (.setInitializationFailFast config false)
-  (wrap-with-delayed-init (HikariDataSource. config) init-fn timeout))
+  ([^HikariConfig config init-fn timeout]
+   (connection-pool-with-delayed-init config init-fn nil timeout))
+  ([^HikariConfig config init-fn init-datasource timeout]
+   (let [datasource (HikariDataSource. config)]
+     (.setInitializationFailFast config false)
+     (if init-datasource
+       (wrap-with-delayed-init datasource init-fn init-datasource timeout)
+       (wrap-with-delayed-init datasource init-fn timeout)))))

--- a/test/puppetlabs/jdbc_util/migration_test.clj
+++ b/test/puppetlabs/jdbc_util/migration_test.clj
@@ -1,0 +1,13 @@
+(ns puppetlabs.jdbc-util.migration-test
+  (:require [puppetlabs.jdbc-util.migration :as migration]
+            [clojure.test :refer :all]))
+
+(deftest spec->migration-db-spec-test
+  (testing "when migration-user and migration-password aren't specified"
+    (let [db-spec {:user "foo" :password "bar"}]
+      (is (= db-spec (migration/spec->migration-db-spec db-spec)))))
+  (testing "migration-user and migration-password get munged properly"
+    (let [db-spec {:user "foo" :password "bar"
+                   :migration-user "migrator" :migration-password "awesome"}]
+      (is (= {:user "migrator" :password "awesome"}
+             (migration/spec->migration-db-spec db-spec))))))

--- a/test/puppetlabs/jdbc_util/pool_test.clj
+++ b/test/puppetlabs/jdbc_util/pool_test.clj
@@ -4,6 +4,7 @@
             [puppetlabs.i18n.core :refer [with-user-locale string-as-locale]]
             [puppetlabs.jdbc-util.core :as core]
             [puppetlabs.jdbc-util.core-test :as core-test]
+            [puppetlabs.jdbc-util.migration :as migration]
             [puppetlabs.jdbc-util.pool :as pool])
   (:import com.codahale.metrics.health.HealthCheckRegistry
            [com.zaxxer.hikari HikariConfig HikariDataSource]
@@ -102,7 +103,7 @@
                     ([user pass]
                      (.getConnection this))))]
     (testing "the pool retries until it gets a connection"
-      (let [wrapped (pool/wrap-with-delayed-init mock-ds (fn [_] mock-ds) 1)]
+      (let [wrapped (pool/wrap-with-delayed-init mock-ds (fn [_] mock-ds) {:migration-dir {}} 1)]
         (is (thrown? SQLTransientConnectionException
                      (.getConnection wrapped)))
         (Thread/sleep 2000)
@@ -120,7 +121,7 @@
                    pool/options->hikari-config)]
     (testing "if the init-fn throws an exception it continues to hand out connections normally"
       (let [wrapped (pool/connection-pool-with-delayed-init
-                     config (fn [_] (throw (RuntimeException. "test exception"))) 10000)]
+                     config {:migartion-db {}} (fn [_] (throw (RuntimeException. "test exception"))) 10000)]
         (is (= [{:a 1}] (jdbc/query {:datasource wrapped} ["select 1 as a"])))
         (is (= {:state :error
                 :messages ["Initialization resulted in an error: test exception"]}
@@ -130,7 +131,7 @@
       (let [eo (string-as-locale "eo")]
         (with-user-locale eo
          (let [wrapped (pool/connection-pool-with-delayed-init
-                             config (fn [_] (throw (RuntimeException. "test exception"))) 10000)]
+                        config {:migartion-db {}} (fn [_] (throw (RuntimeException. "test exception"))) 10000)]
                 (is (= [{:a 1}] (jdbc/query {:datasource wrapped} ["select 1 as a"])))
                 (is (= {:state :error
                         :messages ["This_is_a_translated_string: test exception"]}
@@ -140,30 +141,29 @@
   (let [test-pool (-> core-test/test-db
                       pool/spec->hikari-options
                       pool/options->hikari-config
-                      (pool/connection-pool-with-delayed-init identity 5000))]
+                      (pool/connection-pool-with-delayed-init {:migration-db core-test/test-db} identity 5000))]
     (.getConnection test-pool)
     (is (= {:state :ready}
            (pool/status test-pool)))
     (.close test-pool)))
 
-(deftest init-datasource-test
+(deftest migration-db-spec-test
   (let [datasource (-> core-test/test-db
+                       (assoc :pool-name "AppPool")
                        pool/spec->hikari-options
                        pool/options->hikari-config)
-        init-datasource {:user "migrator"}
-        init-fn (fn [prom]
-                  (fn [init-with]
-                    (deliver prom (:datasource init-with))))]
-    (testing "when init-datasource is omitted"
+        migration-db-spec (assoc core-test/test-db :user "migrator")]
+    (testing "the init function is called with the application datasource"
       (let [!init-with (promise)
-            _ (pool/connection-pool-with-delayed-init datasource (init-fn !init-with) 5000)
-            init-with (deref !init-with 5000 nil)]
-        (testing "the init function is called with the datasource"
-          (is (instance? com.zaxxer.hikari.HikariConfig init-with)))))
-
-    (testing "when init-datasource is provided"
-      (let [!init-with (promise)
-            _ (pool/connection-pool-with-delayed-init datasource (init-fn !init-with) init-datasource 5000)
-            init-with (deref !init-with 5000 nil)]
-        (testing "the init function is called with the init-datasource"
-          (is (= init-datasource init-with)))))))
+            init-fn (fn [init-with]
+                      (deliver !init-with init-with))]
+        (pool/connection-pool-with-delayed-init datasource {:migration-db migration-db-spec} init-fn 5000)
+        (let [init-with (deref !init-with 5000 nil)]
+          (is (= "AppPool" (.getPoolName (:datasource init-with)))))))
+    (testing "the migrate function is called with the migration-db-spec"
+      (let [!migrate-with (promise)]
+        (with-redefs [migration/migrate (fn [migrate-db migration-dir]
+                                          (deliver !migrate-with migrate-db))]
+          (pool/connection-pool-with-delayed-init datasource {:migration-db migration-db-spec} identity 5000)
+          (let [migrate-with (deref !migrate-with 5000 nil)]
+            (is (= migration-db-spec migrate-with))))))))


### PR DESCRIPTION
This PR adds functionality to the initilization of an application database connection where we now accept a migration db-spec that will be passed to migratus to run migrations for the application. This allows us to share pg-logical migration code as well as keep the init-fn running with the application user credentials.