### PR TITLE
(PE-14580) replication status support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,11 @@ To file a bug, please open a Jira ticket against this project. Bugs and PRs are
 addressed on a best-effort basis. Puppet Inc. does not guarantee support for
 this project.
 
-## Maintainenance
+## Running tests
+You'll need PostgreSQL installed (9.4 is the mainly-used version for us right
+now), and set up a "jdbc_util_test" DB and user with password "foobar".
+
+## Maintenance
 Maintainers: Steve Axthelm <steve@puppet.com>
 Tickets: [Puppet Enterprise](https://tickets.puppetlabs.com/browse/ENTERPRISE/). Make sure to set component to "jdbc-util".
 

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -38,22 +38,26 @@ msgid ""
 "permissions."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:29
+#: src/puppetlabs/jdbc_util/pool.clj:36
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:80
+#: src/puppetlabs/jdbc_util/pool.clj:96
+msgid "{0} - An error was encountered during database migration."
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:102
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:83
+#: src/puppetlabs/jdbc_util/pool.clj:106
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:91 src/puppetlabs/jdbc_util/pool.clj:94
+#: src/puppetlabs/jdbc_util/pool.clj:115 src/puppetlabs/jdbc_util/pool.clj:118
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:114
+#: src/puppetlabs/jdbc_util/pool.clj:138
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.jdbc_util \n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
-"POT-Creation-Date: 2016-05-27 11:42:25\n"
+"POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,22 +32,28 @@ msgid_plural "There are not {0} '?'s in the given string"
 msgstr[0] ""
 msgstr[1] ""
 
+#: src/puppetlabs/jdbc_util/middleware.clj:17
+msgid ""
+"The operation could not be performed because of insufficient database "
+"permissions."
+msgstr ""
+
 #: src/puppetlabs/jdbc_util/pool.clj:29
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:74
+#: src/puppetlabs/jdbc_util/pool.clj:80
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:77
+#: src/puppetlabs/jdbc_util/pool.clj:83
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:85 src/puppetlabs/jdbc_util/pool.clj:88
+#: src/puppetlabs/jdbc_util/pool.clj:91 src/puppetlabs/jdbc_util/pool.clj:94
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:108
+#: src/puppetlabs/jdbc_util/pool.clj:114
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,8 @@
             [org.clojure/clojure "1.8.0"]
             [puppetlabs/i18n "0.4.0"]]
 
+  :jar-exclusions [#"\.sw[a-z]$" #"~$" #"logback\.xml$" #"log4j\.properties$"]
+
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}
 

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.6.1"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
+                 [migratus "0.8.28"]
                  [com.zaxxer/HikariCP "2.4.3"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n "0.4.0"]

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -1,0 +1,57 @@
+(ns puppetlabs.jdbc-util.migration
+  (:import java.sql.BatchUpdateException)
+  (:require [migratus.core :as migratus]
+            [migratus.protocols :as mproto]
+            [puppetlabs.jdbc-util.pglogical :as pglogical]))
+
+(defn spec->migration-db-spec
+  "Given a user defined database config, transform the config into a db-spec
+  appropriate for passing to migratus's migrate function."
+  [db-config]
+  (let [user (or (:migration-user db-config)
+                 (:user db-config))
+        password (or (:migration-password db-config)
+                     (:password db-config))]
+    (-> db-config
+        (assoc :user user
+               :password password)
+        (dissoc :migration-user
+                :migration-password))))
+
+(defn migrate
+  "Migrate 'db' using migratus with a given 'migration-dir'."
+  [db migration-dir]
+  (let [have-pglogical (pglogical/has-pglogical-extension? db)
+        pg-schema "public"]
+    (try
+      (migratus/migrate {:store :database
+                         :migration-dir migration-dir
+                         :db db
+                         :modify-sql-fn (if have-pglogical
+                                          #(pglogical/wrap-ddl-for-pglogical % pg-schema)
+                                          identity)})
+      (when have-pglogical
+        (pglogical/update-pglogical-replication-set db pg-schema))
+      (catch BatchUpdateException e
+        (let [root-e (last (seq e))]
+          (throw root-e))))))
+
+(defn migrate-until-just-before
+  "Like 'migrate' but only migrates up to the given
+  migration-id (non-inclusive)."
+  [db migration-dir migration-id]
+  (let [have-pglogical (pglogical/has-pglogical-extension? db)
+        pg-schema "public"]
+    (try
+      (migratus/migrate-until-just-before {:store :database
+                                           :migration-dir migration-dir
+                                           :db db
+                                           :modify-sql-fn (if have-pglogical
+                                                            #(pglogical/wrap-ddl-for-pglogical % pg-schema)
+                                                            identity)}
+                                          migration-id)
+      (when have-pglogical
+        (pglogical/update-pglogical-replication-set db pg-schema))
+      (catch BatchUpdateException e
+        (let [root-e (last (seq e))]
+          (throw root-e))))))

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -31,6 +31,7 @@
                                           #(pglogical/wrap-ddl-for-pglogical % pg-schema)
                                           identity)})
       (when have-pglogical
+        (pglogical/add-status-alias db pg-schema)
         (pglogical/update-pglogical-replication-set db pg-schema))
       (catch BatchUpdateException e
         (let [root-e (last (seq e))]

--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.jdbc-util.pglogical
   (:import [org.postgresql.util PSQLException PSQLState])
   (:require [clojure.java.jdbc :as jdbc]
+            [puppetlabs.i18n.core :refer [tru]]
             [puppetlabs.jdbc-util.core :refer [has-extension?]]))
 
 (defn has-pglogical-extension? [db]
@@ -44,4 +45,96 @@
         false
         (throw e)))))
 
+;;;; Status
 
+(def create-status-alias
+  "CREATE OR REPLACE FUNCTION show_subscription_status(OUT subscription_name text, OUT status text,
+     OUT provider_node text, OUT provider_dsn text, OUT slot_name text, OUT replication_sets text[],
+     OUT forward_origins text[])
+     RETURNS SETOF record AS $$
+       SELECT * FROM pglogical.show_subscription_status();
+     $$ LANGUAGE SQL
+     SECURITY DEFINER;")
+
+(defn add-status-alias
+  "Adds an alias for the pglogical show_subscription_status function, allowing
+  it to be called by any user, not just admin."
+  [db]
+  (jdbc/execute! db [create-status-alias]))
+
+(defn consolidate-replication-status
+  "Given a list of states of pglogical subscriptions, returns
+  the status of data replication. Returns :running if all subscriptions for
+  that database are up and running, :disabled if any subscription has been
+  turned off, :down if any connection has been severed (overrides :disabled),
+  :none if pglogical replication is not configured, or :unknown. Note that
+  :down may not be returned for some time or at all, depending on your
+  postgresql TCP settings."
+  [statuses]
+  (let [all-good? #(every? (partial = "replicating") %)
+        disabled? #(some (partial = "disabled") %)
+        down? #(some (partial = "down") %)]
+    (cond
+      (empty? statuses) :none
+      (all-good? statuses) :running
+      (down? statuses) :down
+      (disabled? statuses) :disabled
+      :else :unknown)))
+
+(defn replica-replication-status
+  "Given a DB connection for a pglogical replica node, returns
+  the status of data replication. Returns :running if all subscriptions for
+  that database are up and running, :disabled if any subscription has been
+  disabled, :down if any connection has been severed (overrides :disabled),
+  :none if pglogical replication is not configured, else :unknown. Note that
+  :down may not be returned for some time or at all, depending on your
+  postgresql TCP settings."
+  [db]
+  (if (has-pglogical-extension? db)
+    (-> (jdbc/query db ["SELECT status from show_subscription_status()"] {:row-fn :status})
+        (consolidate-replication-status))
+    :none))
+
+(defn consolidate-provider-status
+  [statuses]
+  (let [all-active? #(every? true? %)]
+    (case
+      (empty? statuses) :none
+      (all-active? statuses) :active
+      :else :inactive)))
+
+(defn provider-replication-status
+  "Given a DB connection for a pglogical provider node, query whether the
+  node's subscription is currently active or not. Returns :active or
+  :inactive, or :none if pglogical is not installed."
+  [db]
+  (if (has-pglogical-extension? db)
+    (jdbc/query db ["SELECT active FROM pg_replication_slots WHERE database = ?" (:db db)])
+    :none))
+
+(defn replication-status
+  "Given a DB connection for a pglogical node and the role of that node,
+  :source or :replica, query replication status. Returns a map reporting the
+  role and its status. Valid status values vary depending on the role; see
+  other replication-status functions for more information."
+  [db role]
+  (let [status (if (= :source role)
+                 (provider-replication status db)
+                 (replica-replication-status db))]
+    {:role role
+     :status status}))
+
+(defn replication-alert
+  "Produces an alert that can be used if replication is down. This is only a
+  function for localization reasons.
+
+  This function takes a service name and a replication state, which can be one
+  of: :disabled, :down, or :unknown. It then returns a human-readable message."
+  [service-name replication-state]
+  (let [construct-error (fn [message] {:severity "error"
+                                       :message message})]
+
+  (case replication-state
+    :down (construct-error (tru "Database replication for {0} is currently down." service-name))
+    :disabled (construct-error (tru "Database replication for {0} has been disabled." service-name))
+    :unknown (construct-error (tru "Database replication for {0} is in an unknown state.")))))

--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -155,9 +155,9 @@
   "Create a function which wraps the pglogical show_subscription_status
   function, allowing it to be called by any user, not just admin. This function
   is used by pglogical replication status, and is required for it to function."
-  [db]
+  [db schema]
   (jdbc/execute! db [(if (has-pglogical-extension? db)
-                       (wrap-ddl-for-pglogical create-status-alias-sql "public")
+                       (wrap-ddl-for-pglogical create-status-alias-sql schema)
                        create-status-alias-sql)]))
 
 (defn combined-replication-status

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -73,67 +73,69 @@
 (defn wrap-with-delayed-init
   "Wraps a connection pool that loops trying to get a connection, and then runs
   init-fn (with the connection as argument) before returning any connections to
-  the application. Accepts a timeout in ms that's used when deferencing the
+  the application. Accepts a timeout in ms that's used when dereferencing the
   future and by the status check. The datasource should have
   initialization-fail-fast set before being created or this is pointless."
-  [^HikariDataSource datasource init-fn timeout]
-  (when-not (.getHealthCheckRegistry datasource)
-    (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
-  (let [init-error (atom nil)
-        pool-future
-        (future
-          (loop []
-            (if-let [result
-                     (try
-                       ;; Try to get a connection to make sure the db is ready
-                       (.close (.getConnection datasource))
-                       (try (init-fn {:datasource datasource})
-                            (catch Exception e
-                              (swap! init-error (constantly e))
-                              (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName datasource)))))
-                       datasource
-                       (catch SQLTransientException e
-                         (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
-                         nil))]
-              result
-              (recur))))]
-    (reify
-      DataSource
-      (getConnection [this]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
-      (getConnection [this username password]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
-                        username
-                        password))
+  ([^HikariDataSource datasource init-fn timeout]
+   (wrap-with-delayed-init datasource init-fn datasource timeout))
+  ([^HikariDataSource datasource init-fn init-datasource timeout]
+   (when-not (.getHealthCheckRegistry datasource)
+     (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
+   (let [init-error (atom nil)
+         pool-future
+         (future
+           (loop []
+             (if-let [result
+                      (try
+                          ;; Try to get a connection to make sure the db is ready
+                          (.close (.getConnection datasource))
+                        (try (init-fn {:datasource init-datasource})
+                          (catch Exception e
+                            (swap! init-error (constantly e))
+                            (log/errorf e (trs "{0} - An error was encountered during initialization." (.getPoolName init-datasource)))))
+                        datasource
+                        (catch SQLTransientException e
+                          (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying." (.getPoolName datasource)))
+                          nil))]
+               result
+               (recur))))]
+     (reify
+       DataSource
+       (getConnection [this]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
+       (getConnection [this username password]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
+                         username
+                         password))
 
-      Closeable
-      (close [this]
-        (.close datasource))
+       Closeable
+       (close [this]
+         (.close datasource))
 
-      PoolStatus
-      (status [this]
-        (if (realized? pool-future)
-          (let [connectivity-check (str (.getPoolName datasource)
-                                        ".pool.ConnectivityCheck")
-                health-result (.runHealthCheck
-                               (.getHealthCheckRegistry datasource)
-                               connectivity-check)
-                healthy? (and (.isHealthy health-result)
-                              (nil? @init-error))
-                messages (remove nil? [(some->> @init-error
-                                                (.getMessage)
-                                                (tru "Initialization resulted in an error: {0}"))
-                                       (.getMessage health-result)])]
-            (cond-> {:state (if healthy?
-                              :ready
-                              :error)}
-              (not healthy?) (merge {:messages messages})))
-          {:state :starting}))
+       PoolStatus
+       (status [this]
+         (if (realized? pool-future)
+           (let [connectivity-check (str (.getPoolName datasource)
+                                         ".pool.ConnectivityCheck")
+                 health-result (.runHealthCheck
+                                (.getHealthCheckRegistry datasource)
+                                connectivity-check)
+                 healthy? (and (.isHealthy health-result)
+                               (nil? @init-error))
+                 messages (remove nil? [(some->> @init-error
+                                                 (.getMessage)
+                                                 (tru "Initialization resulted in an error: {0}"))
+                                        (.getMessage health-result)])]
+             (cond-> {:state (if healthy?
+                               :ready
+                               :error)}
+               (not healthy?) (merge {:messages messages})))
+           {:state :starting}))
 
-      (init-error [this]
-        @init-error))))
+       (init-error [this]
+         @init-error)))))
 
 (defn connection-pool-with-delayed-init
   "Create a connection pool that loops trying to get a connection, and then runs
@@ -141,6 +143,11 @@
   the application. Accepts a timeout in ms that's used when deferencing the
   future. This overrides the value of initialization-fail-fast and always sets
   it to false. "
-  [^HikariConfig config init-fn timeout]
-  (.setInitializationFailFast config false)
-  (wrap-with-delayed-init (HikariDataSource. config) init-fn timeout))
+  ([^HikariConfig config init-fn timeout]
+   (connection-pool-with-delayed-init config init-fn nil timeout))
+  ([^HikariConfig config init-fn init-datasource timeout]
+   (let [datasource (HikariDataSource. config)]
+     (.setInitializationFailFast config false)
+     (if init-datasource
+       (wrap-with-delayed-init datasource init-fn init-datasource timeout)
+       (wrap-with-delayed-init datasource init-fn timeout)))))

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -77,74 +77,83 @@
   init-fn (with the connection as argument) before returning any connections to
   the application. Accepts a timeout in ms that's used when dereferencing the
   future and by the status check. The datasource should have
-  initialization-fail-fast set before being created or this is pointless."
-  [^HikariDataSource datasource {:keys [migration-db migration-dir]} init-fn timeout]
-  (when-not (.getHealthCheckRegistry datasource)
-    (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
-  (let [init-error (atom nil)
-        pool-future
-        (future
-          (loop []
-            (if-let [result
-                     (try
-                       ;; Try to get a connection to make sure the db is ready
-                       (.close (.getConnection datasource))
-                       (try
-                         (migration/migrate migration-db migration-dir)
-                         (catch Exception e
-                           (reset! init-error e)
-                           (log/errorf e (trs "{0} - An error was encountered during database migration."
-                                              (:subname migration-db "unknown")))))
-                       (try
-                         (init-fn {:datasource datasource})
-                         (catch Exception e
-                           (reset! init-error e)
-                           (log/errorf e (trs "{0} - An error was encountered during initialization."
-                                              (.getPoolName datasource)))))
-                       datasource
-                       (catch SQLTransientException e
-                         (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying."
-                                           (.getPoolName datasource)))
-                         nil))]
-              result
-              (recur))))]
-    (reify
-      DataSource
-      (getConnection [this]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
-      (getConnection [this username password]
-        (.getConnection (or (deref pool-future timeout nil)
-                            (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
-                        username
-                        password))
+  initialization-fail-fast set before being created or this is pointless.
 
-      Closeable
-      (close [this]
-        (.close datasource))
+  migration-opts is a map of:
+    :migration-dir, the path to the migratus migration directory on the classpath
+    :migration-db, the connection map for the db used for migrations
 
-      PoolStatus
-      (status [this]
-        (if (realized? pool-future)
-          (let [connectivity-check (str (.getPoolName datasource)
-                                        ".pool.ConnectivityCheck")
-                health-result (.runHealthCheck
-                               (.getHealthCheckRegistry datasource)
-                               connectivity-check)
-                healthy? (and (.isHealthy health-result)
-                              (nil? @init-error))
-                messages (remove nil? [(some->> @init-error
-                                                (.getMessage)
-                                                (tru "Initialization resulted in an error: {0}"))
-                                       (.getMessage health-result)])]
-            (cond-> {:state (if healthy?
-                              :ready
-                              :error)}
-              (not healthy?) (merge {:messages messages})))
-          {:state :starting}))
+  If migration-opts is nil or not passed, the migration step is skipped."
+  ([^HikariDataSource datasource init-fn timeout]
+   (wrap-with-delayed-init datasource nil init-fn timeout))
+  ([^HikariDataSource datasource migration-opts init-fn timeout]
+   (when-not (.getHealthCheckRegistry datasource)
+     (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
+   (let [init-error (atom nil)
+         pool-future
+         (future
+           (loop []
+             (if-let [result
+                      (try
+                        ;; Try to get a connection to make sure the db is ready
+                        (.close (.getConnection datasource))
+                        (when-let [{:keys [migration-db migration-dir]} migration-opts]
+                          (try
+                            (migration/migrate migration-db migration-dir)
+                            (catch Exception e
+                              (reset! init-error e)
+                              (log/errorf e (trs "{0} - An error was encountered during database migration."
+                                                 (:subname migration-db "unknown"))))))
+                        (try
+                          (init-fn {:datasource datasource})
+                          (catch Exception e
+                            (reset! init-error e)
+                            (log/errorf e (trs "{0} - An error was encountered during initialization."
+                                               (.getPoolName datasource)))))
+                        datasource
+                        (catch SQLTransientException e
+                          (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying."
+                                            (.getPoolName datasource)))
+                          nil))]
+               result
+               (recur))))]
+     (reify
+       DataSource
+       (getConnection [this]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))))
+       (getConnection [this username password]
+         (.getConnection (or (deref pool-future timeout nil)
+                             (throw (SQLTransientConnectionException. (tru "Timeout waiting for the database pool to become ready."))))
+                         username
+                         password))
 
-      (init-error [this]
-        @init-error))))
+       Closeable
+       (close [this]
+         (.close datasource))
+
+       PoolStatus
+       (status [this]
+         (if (realized? pool-future)
+           (let [connectivity-check (str (.getPoolName datasource)
+                                         ".pool.ConnectivityCheck")
+                 health-result (.runHealthCheck
+                                (.getHealthCheckRegistry datasource)
+                                connectivity-check)
+                 healthy? (and (.isHealthy health-result)
+                               (nil? @init-error))
+                 messages (remove nil? [(some->> @init-error
+                                                 (.getMessage)
+                                                 (tru "Initialization resulted in an error: {0}"))
+                                        (.getMessage health-result)])]
+             (cond-> {:state (if healthy?
+                               :ready
+                               :error)}
+               (not healthy?) (merge {:messages messages})))
+           {:state :starting}))
+
+       (init-error [this]
+         @init-error)))))
 
 (defn connection-pool-with-delayed-init
   "Create a connection pool that loops trying to get a connection, and then runs
@@ -152,7 +161,9 @@
   the application. Accepts a timeout in ms that's used when deferencing the
   future. This overrides the value of initialization-fail-fast and always sets
   it to false. "
-  [^HikariConfig config migration-options init-fn timeout]
-  (let [datasource (HikariDataSource. config)]
-    (.setInitializationFailFast config false)
-    (wrap-with-delayed-init datasource migration-options init-fn timeout)))
+  ([^HikariConfig config init-fn timeout]
+   (connection-pool-with-delayed-init config nil init-fn timeout))
+  ([^HikariConfig config migration-options init-fn timeout]
+   (let [datasource (HikariDataSource. config)]
+     (.setInitializationFailFast config false)
+     (wrap-with-delayed-init datasource migration-options init-fn timeout))))

--- a/test/puppetlabs/jdbc_util/migration_test.clj
+++ b/test/puppetlabs/jdbc_util/migration_test.clj
@@ -1,0 +1,13 @@
+(ns puppetlabs.jdbc-util.migration-test
+  (:require [puppetlabs.jdbc-util.migration :as migration]
+            [clojure.test :refer :all]))
+
+(deftest spec->migration-db-spec-test
+  (testing "when migration-user and migration-password aren't specified"
+    (let [db-spec {:user "foo" :password "bar"}]
+      (is (= db-spec (migration/spec->migration-db-spec db-spec)))))
+  (testing "migration-user and migration-password get munged properly"
+    (let [db-spec {:user "foo" :password "bar"
+                   :migration-user "migrator" :migration-password "awesome"}]
+      (is (= {:user "migrator" :password "awesome"}
+             (migration/spec->migration-db-spec db-spec))))))

--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -8,3 +8,18 @@
               " create table test(a integer);''"
               "); end;';")
          (wrap-ddl-for-pglogical "create table test(a integer);" "public"))))
+
+(deftest consolidate-replication-status-test
+  (testing "when 2 subscriptions are running, returns :running"
+    (is (= :running (consolidate-replication-status ["replicating" "replicating"]))))
+  (testing "when one subscription is down,"
+    (testing "and the rest are running, returns :down"
+      (is (= :down (consolidate-replication-status ["replicating" "down"]))))
+    (testing "and another is disabled, returns :down"
+      (is (= :down (consolidate-replication-status ["disabled" "down"])))))
+  (testing "when one subscription is disabled,"
+    (testing "and the rest are running, returns :disabled"
+      (is (= :disabled (consolidate-replication-status ["replicating" "disabled"])))))
+  (testing "when no subscriptions are configured, returns :disabled"
+    (testing "and the rest are running, returns :none"
+      (is (= :none (consolidate-replication-status []))))))

--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -9,17 +9,17 @@
               "); end;';")
          (wrap-ddl-for-pglogical "create table test(a integer);" "public"))))
 
-(deftest consolidate-replication-status-test
+(deftest consolidate-replica-status-test
   (testing "when 2 subscriptions are running, returns :running"
-    (is (= :running (consolidate-replication-status ["replicating" "replicating"]))))
+    (is (= :running (consolidate-replica-status ["replicating" "replicating"]))))
   (testing "when one subscription is down,"
     (testing "and the rest are running, returns :down"
-      (is (= :down (consolidate-replication-status ["replicating" "down"]))))
+      (is (= :down (consolidate-replica-status ["replicating" "down"]))))
     (testing "and another is disabled, returns :down"
-      (is (= :down (consolidate-replication-status ["disabled" "down"])))))
+      (is (= :down (consolidate-replica-status ["disabled" "down"])))))
   (testing "when one subscription is disabled,"
     (testing "and the rest are running, returns :disabled"
-      (is (= :disabled (consolidate-replication-status ["replicating" "disabled"])))))
+      (is (= :disabled (consolidate-replica-status ["replicating" "disabled"])))))
   (testing "when no subscriptions are configured, returns :disabled"
     (testing "and the rest are running, returns :none"
-      (is (= :none (consolidate-replication-status []))))))
+      (is (= :none (consolidate-replica-status []))))))


### PR DESCRIPTION
This PR changes the connection-pool-with-delayed-init function to
expect a migration-db-spec (a normal JDBC db-spec) with a migratus
:migration-dir assoc'd on. This allows us to share the
pg-logical, migration code across all the projects using jdbc-util and
allows us to keep the initilization datasource and migration datasource
as separate entities (because for most of the projects already using the
init-fn, the init-fn really *should* be run as the application user, not
the migration user).

This PR also adds support functionality for getting the status of pglogical replication.