### PR TITLE
(PE-16181) Block replica startups waiting for migrations

### DIFF
--- a/dev-resources/test-migrations/20140114131703-base-schema.up.sql
+++ b/dev-resources/test-migrations/20140114131703-base-schema.up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS foo (
+  bar TEXT PRIMARY KEY
+);
+--;;

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Database status check timed out after 4 seconds."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/core.clj:143
+#: src/puppetlabs/jdbc_util/core.clj:156
 msgid "There are no '?'s in the given string"
 msgid_plural "There are not {0} '?'s in the given string"
 msgstr[0] ""
@@ -38,26 +38,42 @@ msgid ""
 "permissions."
 msgstr ""
 
+#: src/puppetlabs/jdbc_util/pglogical.clj:143
+msgid "Database replication for {0} is currently down."
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pglogical.clj:144
+msgid "Database replication for {0} has been disabled."
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pglogical.clj:145
+msgid "Database replication for {0} is in an unknown state."
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pglogical.clj:146
+msgid "Database replication for {0} is inactive"
+msgstr ""
+
 #: src/puppetlabs/jdbc_util/pool.clj:36
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:96
+#: src/puppetlabs/jdbc_util/pool.clj:124
 msgid "{0} - An error was encountered during database migration."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:102
+#: src/puppetlabs/jdbc_util/pool.clj:130
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:106
+#: src/puppetlabs/jdbc_util/pool.clj:134
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:115 src/puppetlabs/jdbc_util/pool.clj:118
+#: src/puppetlabs/jdbc_util/pool.clj:143 src/puppetlabs/jdbc_util/pool.clj:146
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:138
+#: src/puppetlabs/jdbc_util/pool.clj:166
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,9 @@
 
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.6.1"]
+                 [org.clojure/java.jdbc "0.6.2-alpha3"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
-                 [migratus "0.8.28"]
+                 [migratus "0.8.29"]
                  [com.zaxxer/HikariCP "2.4.3"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n "0.4.0"]

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -56,3 +56,12 @@
       (catch BatchUpdateException e
         (let [root-e (last (seq e))]
           (throw root-e))))))
+
+(defn uncompleted-migrations
+  "Returns a list of migrations in migration-dir that haven't run in db"
+  [db migration-dir]
+  (let [config {:store :database
+                :migration-dir migration-dir
+                :db db}]
+    (migratus/uncompleted-migrations (doto (mproto/make-store config)
+                                       (mproto/connect)))))


### PR DESCRIPTION
This commit blocks the startup of replicas while there are pending
migrations (i.e. replicas will wait for the migrations to be replicated
from the master).