### PR TITLE
(PE-15626) Fix reconcile-sequence-for-column!

### DIFF
--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -183,6 +183,6 @@
   (if-let [sequence-name (get-sequence-name-for-column db table column)]
     (jdbc/with-db-transaction [txn-db db]
       (jdbc/execute! txn-db [(format "LOCK TABLE \"%s\" IN EXCLUSIVE MODE NOWAIT" table)])
-      (jdbc/query txn-db [(format "SELECT setval('%s', COALESCE(max(\"%s\"), 0)) FROM \"%s\""
+      (jdbc/query txn-db [(format "SELECT setval('%s', COALESCE(max(\"%s\")+1, 1), false) FROM \"%s\""
                                   sequence-name column table)]))
     (throw (Exception. (format "No sequence found for column %s on table %s." table column)))))

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -243,9 +243,14 @@
     (testing "given a table with a sequence object"
       (jdbc/execute! test-db ["DROP TABLE IF EXISTS sequence_test CASCADE"])
       (jdbc/execute! test-db ["CREATE TABLE sequence_test (id BIGSERIAL PRIMARY KEY)"])
+
+      (testing "when the table is empty, reconcile-sequence-for-column! sets the sequence to 1"
+        (reconcile-sequence-for-column! test-db "sequence_test" "id")
+        (insert-dummy)
+        (is (= 1 (max-id))))
+
       (testing "where the sequence object is out of date"
         (dotimes [_ 5] (insert-dummy))
-        (insert-dummy)
         (set-sequence-value 1)
         (testing "inserting fails"
           (is (thrown-with-msg? PSQLException #"duplicate key value"


### PR DESCRIPTION
Prior to this commit, `reconcile-sequence-for-column!` would cause an error when given an empty column.

Specifically, it would attempt to set the sequence to 0, which is an illegal value. As of this commit, it will instead set the sequence to 1, passing an additional parameter that signals that the next value emitted should be the current value (i.e., post-increment instead of pre-increment).