### PR TITLE
(PE-14580) Add timeout to pglogical status check

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -38,19 +38,19 @@ msgid ""
 "permissions."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:143
+#: src/puppetlabs/jdbc_util/pglogical.clj:144
 msgid "Database replication for {0} is currently down."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:144
+#: src/puppetlabs/jdbc_util/pglogical.clj:145
 msgid "Database replication for {0} has been disabled."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:145
+#: src/puppetlabs/jdbc_util/pglogical.clj:146
 msgid "Database replication for {0} is in an unknown state."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:146
+#: src/puppetlabs/jdbc_util/pglogical.clj:147
 msgid "Database replication for {0} is inactive"
 msgstr ""
 
@@ -58,22 +58,22 @@ msgstr ""
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:124
+#: src/puppetlabs/jdbc_util/pool.clj:125
 msgid "{0} - An error was encountered during database migration."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:130
+#: src/puppetlabs/jdbc_util/pool.clj:131
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:134
+#: src/puppetlabs/jdbc_util/pool.clj:135
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:143 src/puppetlabs/jdbc_util/pool.clj:146
+#: src/puppetlabs/jdbc_util/pool.clj:144 src/puppetlabs/jdbc_util/pool.clj:147
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:166
+#: src/puppetlabs/jdbc_util/pool.clj:167
 msgid "Initialization resulted in an error: {0}"
 msgstr ""

--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -32,9 +32,11 @@
      (future-cancel f#)
      result#))
 
+(def db-status-timeout-secs 4)
+
 (defn db-up?
   [db-spec]
-  (let [result (with-timeout 4 :timeout
+  (let [result (with-timeout db-status-timeout-secs :timeout
                  (try (let [select-42 "SELECT (a - b) AS answer FROM (VALUES ((7 * 7), 7)) AS x(a, b)"
                             [{:keys [answer]}] (jdbc/query db-spec [select-42])]
                         (= answer 42))

--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -2,7 +2,7 @@
   (:import [org.postgresql.util PSQLException PSQLState])
   (:require [clojure.java.jdbc :as jdbc]
             [puppetlabs.i18n.core :refer [tru]]
-            [puppetlabs.jdbc-util.core :refer [has-extension?]]))
+            [puppetlabs.jdbc-util.core :refer [has-extension? with-timeout db-status-timeout-secs]]))
 
 (defn has-pglogical-extension? [db]
   (has-extension? db "pglogical"))
@@ -119,15 +119,17 @@
 
 (defn- replication-status
   "Given a DB connection for a pglogical node and the replication mode of :none,
-  :source or :replica, query replication status. Returns a status keyword,
-  or :none if replication-mode is :none. Valid status values vary depending on
-  thew role; see other replication-status functions for more information."
-  [db replication-mode]
-  (case replication-mode
-    :source (provider-replication-status db)
-    :replica (replica-replication-status db)
-    :none :none
-    nil :none))
+  :source or :replica, query replication status. Returns a status
+  keyword (possibly :unknown), or :none if replication-mode is :none. Valid
+  status values vary depending on thew role; see other replication-status
+  functions for more information."
+  [db replication-mode timeout]
+  (with-timeout timeout :unknown
+    (case replication-mode
+      :source (provider-replication-status db)
+      :replica (replica-replication-status db)
+      :none :none
+      nil :none)))
 
 (defn- format-replication-alert
   "Produce an alert that can be used if replication is down.
@@ -174,9 +176,11 @@
 
   The value at the :structured-status key should be included in the tk-status
   response at the path [:status :replication]."
-  [db replication-mode service-name]
-  (let [status (replication-status db replication-mode)]
-    {:alerts (some-> (format-replication-alert service-name status)
-                     vector)
-     :structured-status {:mode replication-mode
-                         :status status}}))
+  ([db replication-mode service-name]
+   (combined-replication-status db replication-mode service-name db-status-timeout-secs))
+  ([db replication-mode service-name timeout]
+   (let [status (replication-status db replication-mode timeout)]
+     {:alerts (some-> (format-replication-alert service-name status)
+                      vector)
+      :structured-status {:mode replication-mode
+                          :status status}})))

--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -1,6 +1,6 @@
 (ns puppetlabs.jdbc-util.pglogical-test
   (:require [clojure.test :refer :all]
-            [puppetlabs.jdbc-util.pglogical :refer :all]))
+            [puppetlabs.jdbc-util.pglogical :refer :all :as pglogical]))
 
 (deftest wrap-ddl-for-pglogical-test
   (is (= (str "do 'begin perform"
@@ -23,3 +23,13 @@
   (testing "when no subscriptions are configured, returns :disabled"
     (testing "and the rest are running, returns :none"
       (is (= :none (consolidate-replica-status []))))))
+
+(deftest replication-status-test
+  (testing "when no database connection is available"
+    (with-redefs [pglogical/provider-replication-status (fn [db]
+                                                          (Thread/sleep 10000))]
+      (is (= :unknown (#'pglogical/replication-status {:classname "org.postgresql.Driver"
+                                                       :subprotocol "postgresql"
+                                                       :subname "fakedb"
+                                                       :user "fakedb"
+                                                       :password "fakedb"} :source))))))


### PR DESCRIPTION
This commit adds a timeout to the pglogical status check (like db-up?
has for the database connection check). Before this commit the
replication status check wouldn't timeout but the service level
trapperkeeper-status check would, putting the whole service in an
unknown state.