### PR TITLE
(maint) Refine/de-nilify migration spec

### DIFF
--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -8,15 +8,15 @@
   "Given a user defined database config, transform the config into a db-spec
   appropriate for passing to migratus's migrate function."
   [db-config]
-  (let [user (or (:migration-user db-config)
-                 (:user db-config))
-        password (or (:migration-password db-config)
-                     (:password db-config))]
-    (-> db-config
-        (assoc :user user
-               :password password)
-        (dissoc :migration-user
-                :migration-password))))
+  (let [?user (or (:migration-user db-config)
+                  (:user db-config))
+        ?password (if (:migration-user db-config)
+                    (:migration-password db-config)
+                    (:password db-config))]
+    (cond-> db-config
+      :always   (dissoc :password, :migration-user, :migration-password)
+      ?user     (assoc :user ?user)
+      ?password (assoc :password ?password))))
 
 (defn migrate
   "Migrate 'db' using migratus with a given 'migration-dir'."

--- a/test/puppetlabs/jdbc_util/migration_test.clj
+++ b/test/puppetlabs/jdbc_util/migration_test.clj
@@ -6,8 +6,22 @@
   (testing "when migration-user and migration-password aren't specified"
     (let [db-spec {:user "foo" :password "bar"}]
       (is (= db-spec (migration/spec->migration-db-spec db-spec)))))
+
   (testing "migration-user and migration-password get munged properly"
     (let [db-spec {:user "foo" :password "bar"
                    :migration-user "migrator" :migration-password "awesome"}]
       (is (= {:user "migrator" :password "awesome"}
-             (migration/spec->migration-db-spec db-spec))))))
+             (migration/spec->migration-db-spec db-spec)))))
+
+  (testing "when no password is set"
+    (let [db-spec {:user "foo"}]
+      (testing "none gets used"
+        (is (= {:user "foo"}
+               (migration/spec->migration-db-spec db-spec))))))
+
+  (testing "when no migration-password is set"
+    (let [db-spec {:user "foo", :password "bar"
+                   :migration-user "migratey"}]
+      (testing "none gets used"
+        (is (= {:user "migratey"}
+               (migration/spec->migration-db-spec db-spec)))))))


### PR DESCRIPTION
Previously, the output of spec->migration-db-spec could:

1. contain nil values for the :user and/or :password keys
2. match the :password value with the :migration-user value (or various
other permutations)

Neither of these is desirable. In practical usage, passwords are not
always supplied, in which case the key should not be present in the
final map. Furthermore, it should be fine to use passwords for
migrations but not for normal use, or vice-versa.

This commit addresses both problems.

Signed-off-by: Justin Holguin <justin.h.holguin@gmail.com>