### PR TITLE
(maint) Remove NOWAIT in seq reconciliation lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.12
+
+ * Remove the `NOWAIT` argument when locking a table for
+   `reconcile-sequence-for-column!`. This is unlikely to do anything but cause
+   problems in most circumstances.
+
 ## 0.4.11
 
  * Fixed a bug with `spec->migration-db-spec` that would allow nil `:password`

--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -197,7 +197,7 @@
   [db table column]
   (if-let [sequence-name (get-sequence-name-for-column db table column)]
     (jdbc/with-db-transaction [txn-db db]
-      (jdbc/execute! txn-db [(format "LOCK TABLE \"%s\" IN EXCLUSIVE MODE NOWAIT" table)])
+      (jdbc/execute! txn-db [(format "LOCK TABLE \"%s\" IN EXCLUSIVE MODE" table)])
       (jdbc/query txn-db [(format "SELECT setval('%s', COALESCE(max(\"%s\")+1, 1), false) FROM \"%s\""
                                   sequence-name column table)]))
     (throw (Exception. (format "No sequence found for column %s on table %s." table column)))))


### PR DESCRIPTION
It's unnecessary to assume that we can't wait for a lock on a table for
updating sequence objects. This is more likely to cause problems than
prevent them.