### PR TITLE
(maint) Update migratus dependency to 0.8.30

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.6.2-alpha3"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
-                 [migratus "0.8.29"]
+                 [migratus "0.8.30"]
                  [com.zaxxer/HikariCP "2.4.3"]
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/i18n "0.4.0"]


### PR DESCRIPTION
This update removes warning about empty migrations due to a previously
broken regex in migratus.