### PR TITLE
(maint) set FailFast to false *before* connecting

### DIFF
--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -183,6 +183,5 @@
   ([^HikariConfig config init-fn timeout]
    (connection-pool-with-delayed-init config nil init-fn timeout))
   ([^HikariConfig config migration-options init-fn timeout]
-   (let [datasource (HikariDataSource. config)]
-     (.setInitializationFailFast config false)
-     (wrap-with-delayed-init datasource migration-options init-fn timeout))))
+   (.setInitializationFailFast config false)
+   (wrap-with-delayed-init (HikariDataSource. config) migration-options init-fn timeout)))

--- a/test/puppetlabs/jdbc_util/pool_test.clj
+++ b/test/puppetlabs/jdbc_util/pool_test.clj
@@ -109,7 +109,7 @@
         (Thread/sleep 2000)
         (is (= {:state :starting}
                (pool/status wrapped)))
-        (swap! ready (constantly true))
+        (reset! ready true)
         (Thread/sleep 600)
         (.getConnection wrapped)
         ;; allow for some variance due to timing
@@ -195,3 +195,17 @@
 
       (is (= 0 (num-migrations-left)))
       (is (= @init-status :completed)))))
+
+(deftest connection-pool-fails-slow
+  (testing "given a configuration for a non-existent database"
+    (let [options (pool/spec->hikari-options {:user "fakeuser"
+                                              :password "fakepassword"
+                                              :subprotocol "postgresql"
+                                              :subname "nocalhost"
+                                              :connection-timeout 1000})
+          config (pool/options->hikari-config options)]
+      (testing "calling connection-pool-with-delayed-init doesn't throw an exception"
+        (pool/connection-pool-with-delayed-init config
+                                                {}
+                                                nil
+                                                1000)))))


### PR DESCRIPTION
An earlier change inadvertently caused the `.setInitializationFailFast` method to be called *after* the connection was made, at which point it had no effect. This commit restores the correct behavior.