### PR TITLE
(PE-17970) Fix consolidate-provider-status

### DIFF
--- a/src/puppetlabs/jdbc_util/pglogical.clj
+++ b/src/puppetlabs/jdbc_util/pglogical.clj
@@ -102,10 +102,10 @@
   or :none."
   [statuses]
   (let [all-active? #(every? true? %)]
-    (case
-        (empty? statuses) :none
-        (all-active? statuses) :active
-        :else :inactive)))
+    (cond
+      (empty? statuses) :none
+      (all-active? statuses) :active
+      :else :inactive)))
 
 (defn- provider-replication-status
   "Given a DB connection for a pglogical provider node, query whether the

--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -24,6 +24,14 @@
     (testing "and the rest are running, returns :none"
       (is (= :none (consolidate-replica-status []))))))
 
+(deftest consolidate-provider-status-test
+  (are [statuses expected] (= expected (#'pglogical/consolidate-provider-status statuses))
+    '() :none
+    '(true) :active
+    '(false) :inactive
+    '(true true) :active
+    '(true false) :inactive))
+
 (deftest replication-status-test
   (testing "when no database connection is available"
     (with-redefs [pglogical/provider-replication-status (fn [db]


### PR DESCRIPTION
This function was using `case` incorrectly, which would cause it to always(?) report `:inactive` for replication status. This commit fixes the behavior.