### PR TITLE
(PE-18114) add lifetime protocol to pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,27 @@ The status is implemented using an io.dropwizard.metrics HealthCheckRegistry. If
 one is provided to the hikari config under `:health-check-registry` it will be
 used, otherwise one will be created automatically.
 
+#### Lifetime
+
+The pool implements a lifetime protocol (`pool/PoolLifetime`) to provide methods
+of determining if the initialization is complete, cancelling the initialization
+if possible, or waiting on the completion of the initialization.  Additionally
+a new close interface `close-after-ready` waits to close the datasource until
+the init routine is complete.
+
+Before the initialization is complete `init-complete?` returns false.  If the
+initialization routine finishes, fails or was cancelled, `init-complete?` returns
+true.
+
+`cancel-init` will attempt to cancel the async initialization process and return
+true if it was cancelled, or false if it wasn't.  If the init routine has already
+completed, `cancel-init` returns false.
+
+`close-after-ready` has two forms, one that will block forever until the init
+routine completes, or one that accepts a timeout in milliseconds.  If the
+timeout is exceeded prior to the init completing, the routine will attempt to cancel
+the init and then immediately close the connection.
+
 ## Support
 
 To file a bug, please open a Jira ticket against this project. Bugs and PRs are

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/puppetlabs/jdbc_util/core.clj:42
+#: src/puppetlabs/jdbc_util/core.clj:44
 msgid "Status check of db failed with error:"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/core.clj:45
+#: src/puppetlabs/jdbc_util/core.clj:47
 msgid "Database status check timed out after 4 seconds."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/core.clj:156
+#: src/puppetlabs/jdbc_util/core.clj:158
 msgid "There are no '?'s in the given string"
 msgid_plural "There are not {0} '?'s in the given string"
 msgstr[0] ""
@@ -38,42 +38,80 @@ msgid ""
 "permissions."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:144
+#: src/puppetlabs/jdbc_util/pglogical.clj:145
 msgid "Database replication for {0} is currently down."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:145
+#: src/puppetlabs/jdbc_util/pglogical.clj:146
 msgid "Database replication for {0} has been disabled."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:146
+#: src/puppetlabs/jdbc_util/pglogical.clj:147
 msgid "Database replication for {0} is in an unknown state."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pglogical.clj:147
+#: src/puppetlabs/jdbc_util/pglogical.clj:148
 msgid "Database replication for {0} is inactive"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:36
+#: src/puppetlabs/jdbc_util/pool.clj:37
 msgid "{0} is not a supported HikariCP option"
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:125
+#: src/puppetlabs/jdbc_util/pool.clj:122
+msgid "{0} - Starting database initialization"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:128
+msgid "{0} - Starting database migration"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:138
 msgid "{0} - An error was encountered during database migration."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:131
+#: src/puppetlabs/jdbc_util/pool.clj:140
+msgid "{0} - Finished database migration"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:142
+msgid "{0} - Starting post-migration init-fn"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:144
+msgid "{0} - Finished post-migration init-fn"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:147
 msgid "{0} - An error was encountered during initialization."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:135
+#: src/puppetlabs/jdbc_util/pool.clj:151
 msgid "{0} - Error while attempting to connect to database, retrying."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:144 src/puppetlabs/jdbc_util/pool.clj:147
+#: src/puppetlabs/jdbc_util/pool.clj:160 src/puppetlabs/jdbc_util/pool.clj:163
 msgid "Timeout waiting for the database pool to become ready."
 msgstr ""
 
-#: src/puppetlabs/jdbc_util/pool.clj:167
+#: src/puppetlabs/jdbc_util/pool.clj:183
 msgid "Initialization resulted in an error: {0}"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:196
+msgid "{0} - Blocking execution until db init has finished"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:200 src/puppetlabs/jdbc_util/pool.clj:207
+msgid "{0} - Exception generated during init"
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:202
+msgid ""
+"{0} - Blocking execution until db init has finished with {1} millisecond "
+"timeout "
+msgstr ""
+
+#: src/puppetlabs/jdbc_util/pool.clj:218
+msgid "{0} - Cancelling db-init due to timeout"
 msgstr ""


### PR DESCRIPTION
There have been issues with the connection pool being closed prior to
the initialization routines completing.  This results in some
transient failures in tests as well as actual application.

The lifetime funcitons allow the caller to block until the init
routines are complete.  An interface to query the state of the init
routine completion is added.  Finally an interface is provided to
attempt to cancel the init routine, if possible.

Many of the pool unit tests were failing to close the pool after the test was done. 
`with-open` was applied to help with that issue.
