### PR TITLE
(TK-4352) Functions to Check Existence of, Create, and Destroy DBs & Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,14 @@ this project.
 
 ## Running tests
 You'll need PostgreSQL installed (9.4 is the mainly-used version for us right
-now), and set up a "jdbc_util_test" DB and user with password "foobar".
+now), and set up a "jdbc_util_test" DB and user with password "foobar" that has
+the permission to create databases and users.
+
+To give the "jdbc_util_test" user permission to create databases, open up a psql
+session and then run:
+```sql
+ALTER ROLE jdbc_util_test CREATEDB CREATEROLE;
+```
 
 ## License
 

--- a/dev-resources/log4j.properties
+++ b/dev-resources/log4j.properties
@@ -1,5 +1,7 @@
 log4j.rootLogger=INFO, console
-log4j.logger.puppetlabs.jdbc-util.core=DEBUG
+log4j.logger.puppetlabs.jdbc-util=OFF
+log4j.logger.com.zaxxer.hikari=OFF
+log4j.logger.migratus=OFF
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%-5p %c: %m%n

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,3 @@
-(def ks-version "1.0.0")
-
 (defproject puppetlabs/jdbc-util "0.5.1-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
   :url "https://github.com/puppetlabs/jdbc-util"
@@ -14,11 +12,11 @@
                  [org.postgresql/postgresql "9.4.1208.jre7"]
                  [migratus "0.8.30"]
                  [com.zaxxer/HikariCP "2.4.3"]
-                 [puppetlabs/kitchensink ~ks-version]
+                 [puppetlabs/kitchensink "2.2.0"]
                  [puppetlabs/i18n "0.6.0"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]
-                 [cheshire "5.5.0"]]
+                 [cheshire "5.6.1"]]
 
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.21"]
                                   [org.slf4j/slf4j-log4j12 "1.7.21"]

--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.6.2-alpha3"]
+                 [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
                  [migratus "0.8.30"]
                  [com.zaxxer/HikariCP "2.4.3"]

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -20,7 +20,7 @@
   (jdbc/execute! db ["CREATE TABLE books (
                         title TEXT PRIMARY KEY,
                         author TEXT REFERENCES authors (name))"])
-(jdbc/execute! db ["CREATE TABLE weird_junk ( id UUID PRIMARY KEY )"])
+  (jdbc/execute! db ["CREATE TABLE weird_junk ( id UUID PRIMARY KEY )"])
   (jdbc/insert-multi! db :authors
                       [{:name "kafka"  :favorite_color "black"}
                        {:name "borges" :favorite_color "purple"}

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -8,8 +8,7 @@
             [puppetlabs.jdbc-util.core :refer :all]))
 
 (def test-db
-  {:classname "org.postgresql.Driver"
-   :subprotocol "postgresql"
+  {:subprotocol "postgresql"
    :subname (or (System/getenv "JDBCUTIL_DBNAME") "jdbc_util_test")
    :user (or (System/getenv "JDBCUTIL_DBUSER") "jdbc_util_test")
    :password (or (System/getenv "JDBCUTIL_DBPASS") "foobar")})


### PR DESCRIPTION
Add functions that check the existence of, create, and destroy both
databases and users. They all take a DB spec as their first argument.
The DB spec should connect to a database that's not the one being
created or destroyed, and the user it connects as must have the
appropriate permissions for the operation.

Since CREATE/DROP statements cannot be parametrized as we
typically do with our Postgres queries, these functions rely on some
new utilites to verify that their inputs are safe.

Add `pg-sql-escape`, which takes an arbitrary string and returns it in
postgres's dollar-quoted format, which makes it safe to naively
interpolate into raw SQL strings. However, this can only be used in
places where postgres expects strings; it cannot be used to escape
identifiers such as the names of databases, users, or columns.

Add `safe-pg-identifier?`, for use when it's necessary to interpolate
identifiers into an SQL query. This predicate returns true when the
identifier is composed of a safe subset of characters: alphabetical
characters, digits, and the symbols '-' and '_', to the exclusion of all
other symbols.
