### PR TITLE
(maint) Add superuser? option to `create-user!`

### DIFF
--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -108,12 +108,15 @@
   optional options map where the :superuser? option will make the created user
   a superuser if the value is exactly `true` (not just truthy); note that only
   superusers can create more superusers."
-  [admin-db-spec username password]
-  (let [sql (format "CREATE ROLE %s WITH LOGIN PASSWORD %s"
-                    (pg-escape-identifier username)
-                    (pg-escape-string password))]
-    (jdbc/execute! admin-db-spec [sql])
-    nil))
+  ([admin-db-spec username password] (create-user! admin-db-spec username password {}))
+  ([admin-db-spec username password options]
+   (let [{:keys [superuser?]} options
+         sql (format (str "CREATE ROLE %s WITH LOGIN PASSWORD %s" (if (true? superuser?)
+                                                                    " SUPERUSER"))
+                     (pg-escape-identifier username)
+                     (pg-escape-string password))]
+     (jdbc/execute! admin-db-spec [sql])
+     nil)))
 
 (defn drop-user!
   "Given a DB spec that connects with a user besides `username` and has

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -153,6 +153,10 @@
       (testing "works in the simple case"
         (test-with-name (rand-username)))
 
+      (testing "will try to create superusers"
+        (is (thrown-with-msg? PSQLException #"must be superuser"
+              (create-user! test-db "root" "iamroot" {:superuser? true}))))
+
       (testing "works when given names that attempt to break quoting"
         (test-with-name "guccifer\""))
 


### PR DESCRIPTION
The `create-user!` function in `puppetlabs.jdbc-util.core` now takes an optional options map where the `:superuser?` option will cause the function to create the new user as a superuser if the value is exactly `true`.

In addition, Improve the docstrings of `{create,drop}-{user,db}!` and `{user/db}-exists?` functions to talk about the correct things and be consistent with each other in structure & vocabulary.