### PR TITLE
(maint) move to 1.0.0 release and update deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+  * update HikariCP to version 2.6.1
+  * update kitchensink to 0.3.0
+  * update cheshire to 5.7.1
+  * update dev dependency slf4j related items to 1.7.22 to sync with Hikari
+
 ## 0.6.2
   * Fix `create-db!` when the owner of the new database is a different user than
     the one creating the database.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jdbc-util "0.6.3-SNAPSHOT"
+(defproject puppetlabs/jdbc-util "1.0.0-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
   :url "https://github.com/puppetlabs/jdbc-util"
 
@@ -11,15 +11,15 @@
                  [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql "9.4.1208.jre7"]
                  [migratus "0.8.30"]
-                 [com.zaxxer/HikariCP "2.4.3"]
-                 [puppetlabs/kitchensink "2.2.0"]
+                 [com.zaxxer/HikariCP "2.6.1"]
+                 [puppetlabs/kitchensink "2.3.0"]
                  [puppetlabs/i18n "0.8.0"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]
-                 [cheshire "5.6.1"]]
+                 [cheshire "5.7.1"]]
 
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.21"]
-                                  [org.slf4j/slf4j-log4j12 "1.7.21"]
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.22"]
+                                  [org.slf4j/slf4j-log4j12 "1.7.22"]
                                   [log4j/log4j "1.2.17"]]}}
 
   :plugins [[lein-release "1.0.5"]


### PR DESCRIPTION
Update to version 1.0.0
Update HikariCP to 2.6.1
Update dependencies to match current clj-parent project:
Update kitchensink to 0.3.0
Update cheshire to 5.7.1