### PR TITLE
(maint) remove deprecations for initialization-fail-fast

### DIFF
--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -39,7 +39,7 @@
                                (:subname db-spec)))
              (.setUsername (:user db-spec))
              (.setPassword (:password db-spec))
-             (.setInitializationFailFast false))]
+             (.setInitializationFailTimeout -1))]
     {:datasource ds}))
 
 (defmacro with-timeout [timeout-s default & body]

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -223,10 +223,9 @@
   "Create a connection pool that loops trying to get a connection, and then runs
   init-fn (with the connection as argument) before returning any connections to
   the application. Accepts a timeout in ms that's used when deferencing the
-  future. This overrides the value of initialization-fail-fast and always sets
-  it to false. "
+  future. This overrides the value of initialization-fail-timeout to never timeout. "
   ([^HikariConfig config init-fn timeout]
    (connection-pool-with-delayed-init config nil init-fn timeout))
   ([^HikariConfig config migration-options init-fn timeout]
-   (.setInitializationFailFast config false)
+   (.setInitializationFailTimeout config -1)
    (wrap-with-delayed-init (HikariDataSource. config) migration-options init-fn timeout)))


### PR DESCRIPTION
In the more recent versions of Hikari, the config setting
'initializationFailFast' was deprecated in favor of
'initializationFailTimeout'  This updates the uses of
the fail-fast option to use the method sanctioned in
Hikari to disable the feature, namely use a timeout of
-1.