### PR TITLE
(maint) unhandled exceptions in replica mode prevents startup

### DIFF
--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -129,14 +129,14 @@
                           ;; If we're a replica then pglogical will be
                           ;; replicating our migrations for us, so we poll until
                           ;; the migrations have been replicated
-                          (if (= replication-mode :replica)
-                            (wait-for-migrations migration-db migration-dir)
-                            (try
-                              (migration/migrate migration-db migration-dir)
-                              (catch Exception e
-                                (reset! init-error e)
-                                (log/errorf e (trs "{0} - An error was encountered during database migration."
-                                                   (:subname migration-db "unknown"))))))
+                          (try
+                            (if (= replication-mode :replica)
+                              (wait-for-migrations migration-db migration-dir)
+                              (migration/migrate migration-db migration-dir))
+                            (catch Exception e
+                              (reset! init-error e)
+                              (log/errorf e (trs "{0} - An error was encountered during database migration."
+                                                 (:subname migration-db "unknown")))))
                           (log/debug (trs "{0} - Finished database migration" (.getPoolName datasource))))
                         (try
                           (log/debug (trs "{0} - Starting post-migration init-fn" (.getPoolName datasource)))


### PR DESCRIPTION
If a replica mode pool is requested, and an unexpected exception
occurs while the migrations are being performed for that pool,
the exeception isn't caught, nor logged.  This causes the init
pool routine to terminate unexpectededly.

This change catches unhandled exceptions in replica mode and logs
them.