### PR TITLE
(PE-20922) Fix deprecation warning in jdbc-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2
+  * fix deprecation warnings associated with Hikari config option `setInitializationFailFast`
+  
 ## 1.0.1
   * fix an issue where exceptions during migration for a replica were not caught
   

--- a/dev-resources/log4j.properties
+++ b/dev-resources/log4j.properties
@@ -1,6 +1,6 @@
 log4j.rootLogger=INFO, console
 log4j.logger.puppetlabs.jdbc-util=OFF
-log4j.logger.com.zaxxer.hikari=OFF
+log4j.logger.com.zaxxer.hikari=WARN
 log4j.logger.migratus=OFF
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/src/puppetlabs/jdbc_util/core.clj
+++ b/src/puppetlabs/jdbc_util/core.clj
@@ -39,7 +39,7 @@
                                (:subname db-spec)))
              (.setUsername (:user db-spec))
              (.setPassword (:password db-spec))
-             (.setInitializationFailFast false))]
+             (.setInitializationFailTimeout -1))]
     {:datasource ds}))
 
 (defmacro with-timeout [timeout-s default & body]

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -228,5 +228,5 @@
   ([^HikariConfig config init-fn timeout]
    (connection-pool-with-delayed-init config nil init-fn timeout))
   ([^HikariConfig config migration-options init-fn timeout]
-   (.setInitializationFailFast config false)
+   (.setInitializationFailTimeout config -1)
    (wrap-with-delayed-init (HikariDataSource. config) migration-options init-fn timeout)))


### PR DESCRIPTION
Hikari deprecated the setInitializationFailFast() method used when configuring the connection pool. That method now spams the log with deprecation warnings. To fix we use setInitializationFailTimeout(-1) instead. Also updated the log4j.properties to reenable WARN logging for Hikari.