### PR TITLE
(maint) update postgres version and hikariCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 1.0.3
+  * update HikariCP to version 2.7.4
+  * update postgresql driver to 42.1.4
+
 ## 1.0.2
   * fix deprecation warning on 'initializationFailFast' in Hikari configuration
-  
+
 ## 1.0.1
   * fix an issue where exceptions during migration for a replica were not caught
-  
+
 ## 1.0.0
   * update HikariCP to version 2.6.1
   * update kitchensink to 0.3.0

--- a/project.clj
+++ b/project.clj
@@ -9,17 +9,17 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.jdbc "0.6.2-alpha3"]
                  [org.clojure/test.check "0.9.0"]
-                 [org.postgresql/postgresql "9.4.1208.jre7"]
+                 [org.postgresql/postgresql "42.1.4"]
                  [migratus "0.8.30"]
-                 [com.zaxxer/HikariCP "2.6.1"]
+                 [com.zaxxer/HikariCP "2.7.4"]
                  [puppetlabs/kitchensink "2.3.0"]
                  [puppetlabs/i18n "0.8.0"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
                  [io.dropwizard.metrics/metrics-healthchecks "3.1.2"]
                  [cheshire "5.7.1"]]
 
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.22"]
-                                  [org.slf4j/slf4j-log4j12 "1.7.22"]
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.25"]
+                                  [org.slf4j/slf4j-log4j12 "1.7.25"]
                                   [log4j/log4j "1.2.17"]]}}
 
   :plugins [[lein-release "1.0.5"]

--- a/test/puppetlabs/jdbc_util/middleware_test.clj
+++ b/test/puppetlabs/jdbc_util/middleware_test.clj
@@ -1,11 +1,11 @@
 (ns puppetlabs.jdbc-util.middleware-test
-  (:import [org.postgresql.util PSQLException PSQLState])
+  (:import [org.postgresql.util PSQLException ServerErrorMessage])
   (:require [cheshire.core :as json]
             [clojure.test :refer :all]
             [puppetlabs.jdbc-util.middleware :refer :all]))
 
 (deftest pg-permission-error-middleware-test
-  (let [throwing-handler (fn [_] (throw (PSQLException. "SomeMessage" (PSQLState. "42501"))))
+  (let [throwing-handler (fn [_] (throw (PSQLException. (ServerErrorMessage. "C42501"))))
         wrapped (handle-postgres-permission-errors throwing-handler)
         response (wrapped nil)
         response-body (-> response :body (json/parse-string true))]


### PR DESCRIPTION
This updates to the latest postgres driver and updates hikariCP to the
latest version.

The interfaces for the postgres errors changed, and required a slight
refactor of the test to get the correct error code to be generated.