### PR TITLE
(maint) Update for Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: clojure
-lein: lein2
 jdk:
+  - oraclejdk9
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-script: lein2 test :all
+script: lein test :all
+sudo: false
 before_script:
-  - psql -c 'create database jdbc_util_test;' -U postgres
+  - psql -c "create user jdbc_util_test with createdb createrole password 'foobar'" -U postgres
+  - psql -c 'create database jdbc_util_test owner jdbc_util_test' -U postgres
 env:
   global:
     - JDBCUTIL_DBNAME=//127.0.0.1:5432/jdbc_util_test
-    - JDBCUTIL_DBUSER=postgres
-    - JDBCUTIL_DBPASS=
+    - JDBCUTIL_DBUSER=jdbc_util_test
+    - JDBCUTIL_DBPASS=foobar
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,10 @@
 
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.6.2-alpha3"]
+                 [org.clojure/java.jdbc "0.7.5"]
                  [org.clojure/test.check "0.9.0"]
-                 [org.postgresql/postgresql "42.1.4"]
-                 [migratus "0.8.30"]
+                 [org.postgresql/postgresql "42.2.0"]
+                 [migratus "1.0.3" :exclusions [org.clojure/clojure]]
                  [com.zaxxer/HikariCP "2.7.4"]
                  [puppetlabs/kitchensink "2.3.0"]
                  [puppetlabs/i18n "0.8.0"]

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -62,6 +62,7 @@
   [db migration-dir]
   (let [config {:store :database
                 :migration-dir migration-dir
-                :db db}]
-    (migratus/uncompleted-migrations (doto (mproto/make-store config)
-                                       (mproto/connect)))))
+                :db db}
+        store (doto (mproto/make-store config)
+                (mproto/connect))]
+    (migratus/uncompleted-migrations config store)))

--- a/test/puppetlabs/jdbc_util/pool_test.clj
+++ b/test/puppetlabs/jdbc_util/pool_test.clj
@@ -246,7 +246,7 @@
             (let [migrate-with (deref !migrate-with 5000 nil)]
              (is (= migration-db-spec migrate-with)))))))))
 
-(deftest migration-blocks-initilization
+(deftest migration-blocks-initialization
   (let [config (-> core-test/test-db
                    (assoc :pool-name "AppPool")
                    pool/spec->hikari-options


### PR DESCRIPTION
Update libraries so that tests pass on Java 9.

The update to migratus will cause it to add two new columns to the migration
table. This should be handled transparently.