### PR TITLE
(PE-23367) update pglogical-ddl-wrapper to support multiples

### DIFF
--- a/test/puppetlabs/jdbc_util/pglogical_test.clj
+++ b/test/puppetlabs/jdbc_util/pglogical_test.clj
@@ -7,7 +7,16 @@
               " pglogical.replicate_ddl_command(''set local search_path to public;"
               " create table test(a integer);''"
               "); end;';")
-         (wrap-ddl-for-pglogical "create table test(a integer);" "public"))))
+         (wrap-ddl-for-pglogical "create table test(a integer);" "public")))
+
+  (is (= (str "do 'begin perform"
+              " pglogical.replicate_ddl_command(''set local search_path to public;"
+              " ALTER TABLE schema_migrations ADD COLUMN description varchar(1024);"
+              " ALTER TABLE schema_migrations ADD COLUMN applied timestamp;''"
+              "); end;';")
+         (wrap-ddl-for-pglogical ["ALTER TABLE schema_migrations ADD COLUMN description varchar(1024)"
+                                  "ALTER TABLE schema_migrations ADD COLUMN applied timestamp"] "public"))))
+
 
 (deftest consolidate-replica-status-test
   (testing "when 2 subscriptions are running, returns :running"


### PR DESCRIPTION
As part of the migratus update, migratus now does migration of
its own schema_migrations table.  This involves two commands
used to upgrade the database.  For pglogical support, a
wrapper was created that made sure the commands sent were wrapped
in the proper pglogical commands.

The wrapper assumed a single command being sent to be wrapped.

This updates the wrapper to handle both single commands, and a
sequence of commands.  It separates the sequence of commands
with semicolons.