### PR TITLE
(main) Improve pool migration and initialization behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script: lein test :all
 sudo: false
 before_script:
   - psql -c "create user jdbc_util_test with createdb createrole password 'foobar'" -U postgres
+  - psql -c "create user migrator with createdb createrole password 'foobar'" -U postgres
   - psql -c 'create database jdbc_util_test owner jdbc_util_test' -U postgres
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+  * alter pool initialization behavior to retry transients, but fail on everything else.
+  * alter pool getConnection to throw a RuntimeException when trying to use the pool with an initialization failure
+  * alter pool behavior to run migrations when replication-mode is left out of the migration options
+  * multiple test flakeyness issues resolved
+
 ## 1.1.1
   * fix issue with pg-logical wrappers and multiple statements issued by migratus
 

--- a/README.md
+++ b/README.md
@@ -104,17 +104,18 @@ this project.
 
 ## Running tests
 You'll need PostgreSQL installed (9.4 is the mainly-used version for us right
-now), and set up a "jdbc_util_test" DB and user with password "foobar" that has
-the permission to create databases and users.
+now), and set up a "jdbc_util_test" DB and users "jdbc_util_test" and "migrator"
+with password "foobar" that have the permission to create databases and users.
 
-To give the "jdbc_util_test" user permission to create databases, open up a psql
+To give the "jdbc_util_test" and "migrator" users permission to create databases, open up a psql
 session and then run:
 ```sql
 ALTER ROLE jdbc_util_test CREATEDB CREATEROLE;
+ALTER ROLE migrator CREATEDB CREATEROLE;
 ```
 
 ## License
 
-Copyright © 2016 Puppet, Inc.
+Copyright © 2018 Puppet, Inc.
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jdbc-util "1.1.2-SNAPSHOT"
+(defproject puppetlabs/jdbc-util "1.2.0-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
   :url "https://github.com/puppetlabs/jdbc-util"
 

--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -238,7 +238,7 @@
       (is (db-up? pooled-db))
 
       (testing "pooled connections retry, rather than failing immediately"
-        (let [bad-db (assoc test-db :subname "//example.com/xyz")
+        (let [bad-db (assoc test-db :subname "//example.puppetlabs/xyz")
               bad-pool (-> (connection-pool bad-db)
                          (update-in [:datasource] #(doto % (.setConnectionTimeout 5000))))
               start (System/currentTimeMillis)
@@ -246,6 +246,10 @@
                           (catch java.sql.SQLTransientConnectionException _
                             ::timeout))
               end (System/currentTimeMillis)]
+          ;; if we don't explicitly close this, it will keep trying.
+          ;; this test generates "connection timeout" messages, and that is normal
+          (.close (:datasource bad-pool))
+
           (is (<= 5000 (- end start)))
           (is (= ::timeout result)))))))
 


### PR DESCRIPTION
Previously, if an exception occurred while the pool was being created
it was logged, and connections were handed out normally.  This alters
the pool initialization behavior to:
* retry if transient failures occur during initialization
* log failures if non-transient failures are detected
* throw exceptions on getConnection attempts if the database failed to initialize correctly

This also increments the minor version number to 1.2 to indicate an interface
behavioral change.

Many test updates were made to improve the reliability of the tests.