### PR TITLE
(maint) remove the migrator user from pool test

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,13 @@ this project.
 
 ## Running tests
 You'll need PostgreSQL installed (9.4 is the mainly-used version for us right
-now), and set up a "jdbc_util_test" DB and users "jdbc_util_test" and "migrator"
-with password "foobar" that have the permission to create databases and users.
+now), and set up a "jdbc_util_test" DB and user "jdbc_util_test" with password "foobar"
+that has the permission to create databases and users.
 
 To give the "jdbc_util_test" and "migrator" users permission to create databases, open up a psql
 session and then run:
 ```sql
 ALTER ROLE jdbc_util_test CREATEDB CREATEROLE;
-ALTER ROLE migrator CREATEDB CREATEROLE;
 ```
 
 ## License

--- a/test/puppetlabs/jdbc_util/pool_test.clj
+++ b/test/puppetlabs/jdbc_util/pool_test.clj
@@ -248,7 +248,7 @@
                        (assoc :pool-name "AppPool")
                        pool/spec->hikari-options
                        pool/options->hikari-config)
-        migration-db-spec (assoc core-test/test-db :user "migrator")]
+        migration-db-spec core-test/test-db]
     (testing "the init function is called with the application datasource"
       (let [!init-with (promise)
             init-fn (fn [init-with]


### PR DESCRIPTION
The user wasn't being used, and causes problems on jenkins.  This
removes the user and the reference from the README.