### PR TITLE
(maint) remove superuser test

### DIFF
--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -191,10 +191,6 @@
       (testing "works in the simple case"
         (test-with-name (rand-username)))
 
-      (testing "will try to create superusers"
-        (is (thrown-with-msg? PSQLException #"must be superuser"
-              (create-user! test-db "root" "iamroot" {:superuser? true}))))
-
       (testing "works when given names that attempt to break quoting"
         (test-with-name "guccifer\""))
 


### PR DESCRIPTION
A test was eliminated that attempts to create a superuser using a non
superuser account.  This is just testing the psql behavior and is
problematic from a ci standpoint.