### PR TITLE
(maint) modify migration routine to observe thread interruptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+  * alter migration funciton to observe interruptibility of the thread so that migrations can be interrupted
+  * cleanup connection used in `uncompleted-migrations` function to prevent leak.
+
 ## 1.2.0
   * alter pool initialization behavior to retry transients, but fail on everything else.
   * alter pool getConnection to throw a RuntimeException when trying to use the pool with an initialization failure

--- a/src/puppetlabs/jdbc_util/migration.clj
+++ b/src/puppetlabs/jdbc_util/migration.clj
@@ -1,8 +1,11 @@
 (ns puppetlabs.jdbc-util.migration
   (:import java.sql.BatchUpdateException)
-  (:require [migratus.core :as migratus]
+  (:require [clojure.tools.logging :as log]
+            [migratus.core :as migratus]
             [migratus.protocols :as mproto]
+            [puppetlabs.i18n.core :as i18n]
             [puppetlabs.jdbc-util.pglogical :as pglogical]))
+
 
 (defn spec->migration-db-spec
   "Given a user defined database config, transform the config into a db-spec
@@ -22,20 +25,36 @@
   "Migrate 'db' using migratus with a given 'migration-dir'."
   [db migration-dir]
   (let [have-pglogical (pglogical/has-pglogical-extension? db)
-        pg-schema "public"]
+        pg-schema "public"
+        config {:store :database
+                :migration-dir migration-dir
+                :db db
+                :modify-sql-fn (if have-pglogical
+                                 #(pglogical/wrap-ddl-for-pglogical % pg-schema)
+                                 identity)}
+        store (mproto/make-store config)]
     (try
-      (migratus/migrate {:store :database
-                         :migration-dir migration-dir
-                         :db db
-                         :modify-sql-fn (if have-pglogical
-                                          #(pglogical/wrap-ddl-for-pglogical % pg-schema)
-                                          identity)})
+      (log/info (i18n/trs "Starting migrations"))
+      (mproto/connect store)
+      (let [uncompleted-migrations (sort-by mproto/id (migratus/uncompleted-migrations config store))]
+        (doseq [migration uncompleted-migrations]
+          (let [migration-name (migratus/migration-name migration)
+                _ (log/info (i18n/trs "Up {0}" migration-name))
+                result (mproto/migrate-up store migration)]
+            (when-not (= :success result)
+              (log/error (i18n/trs "Failure during migration {0}" migration-name))
+              (throw (RuntimeException. ^String (i18n/trs "Failed running migration {0}. Stopping." migration-name))))
+            (if (Thread/interrupted)
+              (throw (InterruptedException. (i18n/trs "Migrations interrupted because of cancellation.")))))))
       (when have-pglogical
         (pglogical/add-status-alias db pg-schema)
         (pglogical/update-pglogical-replication-set db pg-schema))
       (catch BatchUpdateException e
         (let [root-e (last (seq e))]
-          (throw root-e))))))
+          (throw root-e)))
+      (finally
+        (log/info (i18n/trs "Ending migrations"))
+        (mproto/disconnect store)))))
 
 (defn migrate-until-just-before
   "Like 'migrate' but only migrates up to the given
@@ -63,6 +82,10 @@
   (let [config {:store :database
                 :migration-dir migration-dir
                 :db db}
-        store (doto (mproto/make-store config)
-                (mproto/connect))]
-    (migratus/uncompleted-migrations config store)))
+        store (mproto/make-store config)]
+
+    (try
+      (mproto/connect store)
+      (migratus/uncompleted-migrations config store)
+      (finally
+        (mproto/disconnect store)))))


### PR DESCRIPTION
Update the migration routine to check the state of the thread
interruption (which can happen via a cancellation) to allow
the migrations to terminate early.

Fix an issue where uncompleted-migrations left a database connection
open.