### PR TITLE
(maint) update to migratus 1.0.8 and change migration function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 1.2.2
+  * update to migratus 1.0.8
+  * change migration function to use interruptibility built into migratus.
+
 ## 1.2.1
-  * alter migration funciton to observe interruptibility of the thread so that migrations can be interrupted
+  * alter migration function to observe interruptibility of the thread so that migrations can be interrupted
   * cleanup connection used in `uncompleted-migrations` function to prevent leak.
 
 ## 1.2.0

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,10 @@
 
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.7.5"]
+                 [org.clojure/java.jdbc "0.7.7"]
                  [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql "42.2.0"]
-                 [migratus "1.0.3" :exclusions [org.clojure/clojure]]
+                 [migratus "1.0.8" :exclusions [org.clojure/clojure]]
                  [com.zaxxer/HikariCP "2.7.4"]
                  [puppetlabs/kitchensink "2.3.0"]
                  [puppetlabs/i18n "0.8.0"]


### PR DESCRIPTION
Migratus 1.0.8 contains a feature to allow thread interruptibility.

This updates the pool to leverage that behavior in migratus and
removes a lot of logic that was duplicated from there.