### PR TITLE
(PE-24859) wait for safe migration exit prior to closing pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+  * wait until migrations have reached a safe point before closing the pool.  If the pool is closed during a migration step,
+  the migration is marked as reserved and won't be able to continue.
+
 ## 1.2.2
   * update to migratus 1.0.8
   * change migration function to use interruptibility built into migratus.


### PR DESCRIPTION
In some circumstances, a close-after-ready was used.  The migrations
took longer than the timeout, which triggers the future cancellation.
Unfortunately, not waiting for the future cancel to have an impact prior
to closing the pool causes migratus to fail to clean up the migration
correctly, leaving it in a half-applied state.  This change causes
the pool to wait for the cancellation to have an impact, but also
applies a timeout to prevent a permanent wait scenario.