### PR TITLE
(PE-27018) uncompleted-migrations should have no side-effects 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
+lein: 2.9.1
 jdk:
-  - oraclejdk9
-  - oraclejdk8
+  - openjdk11
+  - openjdk8
 script: lein test :all
 sudo: false
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.5
+  * alter the `uncompleted-migrations` function to not have any side-effects.  Prior to this change, the routine would create the migraiton table if it didn't exist. 
+
 ## 1.2.4 
   * utility methods for transforming data to PGObject jsonb format and reversing the transformation
 


### PR DESCRIPTION
The "uncompleted-migrations" function has the side-effect of creating
the migration table if it doesn't exist.  In the case where we are
a replica system, this can cause issues with pglogical based replication.

This alters the uncompleted-migrations routine to first determine
if the database table exists, and if it does, determine what migrations
remain.  In the case that the table doesn't exist, it returns the
list of all the uncompleted migrations.

It adds tests for the table-exists? function, as well as a test
that (which fails prior to the fix) demonstrates that the migrations
table isn't present when waiting for migrations in a replica scenario.

In a separate commit, update the changelog in preparation for a new release.