### PR TITLE
(PE-32628) support external data migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml.asc
 .lein-failures
 /resources/locales.clj
 /dev-resources/i18n/bin
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.0
+  * update java.jdbc to 0.7.11
+  * update migratus to 1.3.5. This version of migratus has breaking changes.
+  * migrations with multiple statements that lack a separator will now fail
+  * change the `wrap-with-delayed-init` function to handle migrations from multiple directories 
+
 ## 1.2.5
   * alter the `uncompleted-migrations` function to not have any side-effects.  Prior to this change, the routine would create the migraiton table if it didn't exist. 
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jdbc-util "1.2.6-SNAPSHOT"
+(defproject puppetlabs/jdbc-util "1.3.0-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
   :url "https://github.com/puppetlabs/jdbc-util"
 
@@ -7,10 +7,10 @@
 
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/java.jdbc "0.7.7"]
+                 [org.clojure/java.jdbc "0.7.11"]
                  [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql "42.2.0"]
-                 [migratus "1.0.8" :exclusions [org.clojure/clojure]]
+                 [migratus "1.3.5" :exclusions [org.clojure/clojure]]
                  [com.zaxxer/HikariCP "2.7.4"]
                  [puppetlabs/kitchensink "2.3.0"]
                  [puppetlabs/i18n "0.8.0"]

--- a/test/puppetlabs/jdbc_util/pool_test.clj
+++ b/test/puppetlabs/jdbc_util/pool_test.clj
@@ -265,7 +265,7 @@
         (with-redefs [migration/migrate (fn [migrate-db migration-dir]
                                           (deliver !migrate-with migrate-db))]
           (let [wrapped (pool/connection-pool-with-delayed-init
-                          datasource {:migration-db migration-db-spec} identity 5000)]
+                          datasource {:migration-db migration-db-spec :migration-dir "some/relative/path"} identity 5000)]
             (let [migrate-with (deref !migrate-with 5000 nil)]
              (is (= migration-db-spec migrate-with)))
             (pool/close-after-ready wrapped)


### PR DESCRIPTION
This commit changes the migration dir key in the migration-opts
to accept multiple paths.