### PR TITLE
(maint) Don't serialize nil to jsonb by default

### DIFF
--- a/test/puppetlabs/jdbc_util/core_test.clj
+++ b/test/puppetlabs/jdbc_util/core_test.clj
@@ -486,9 +486,13 @@
           jsonb-string (obj->jsonb string)
           jsonb-obj (obj->jsonb obj)
           jsonb-num (obj->jsonb num)]
-      (is (= (type jsonb-string) org.postgresql.util.PGobject))
-      (is (= (type jsonb-obj) org.postgresql.util.PGobject))
-      (is (= (type jsonb-num) org.postgresql.util.PGobject)))))
+      (is (= org.postgresql.util.PGobject (type jsonb-string)))
+      (is (= org.postgresql.util.PGobject (type jsonb-obj)))
+      (is (= org.postgresql.util.PGobject (type jsonb-num)))))
+  (testing "returns nil without serializing it"
+    (is (nil? (obj->jsonb nil))))
+  (testing "serializes nil if allow-null is specified"
+    (is (= org.postgresql.util.PGobject (type (obj->jsonb nil {:allow-null true}))))))
 
 (deftest parse-jsonb-object-test
   (testing "if the resource is not a PGobject, the original object is returned"


### PR DESCRIPTION
Previously, calling (obj->jsonb nil) would result in the value
'null'::jsonb being written to the database. This confusingly bypasses a
NOT NULL constraint on the column (when we read and deserialize the
value, we unexpectedly still get back nil) and is almost never the
desired behavior.

This changes obj->jsonb to return nil when passed nil, with an option to
allow and serialize nil. This will cause attempts to write nil to a NOT
NULL jsonb column to properly result in an error.