### PR TITLE
(PE-35357) Change setHealthCheckRegistry instantiation/a test to accomodate HikariCP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: clojure
 lein: 2.9.1
 jdk:
   - openjdk11
-  - openjdk8
+  - openjdk17
 script: lein test :all
 sudo: false
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.0
+  * move to HikariCP 5.x, minor setHealthCheckRegistry instantiation change to accomodate
+
 ## 1.3.0
   * update java.jdbc to 0.7.11
   * update migratus to 1.3.5. This version of migratus has breaking changes.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jdbc-util "1.3.1-SNAPSHOT"
+(defproject puppetlabs/jdbc-util "1.4.0-SNAPSHOT"
   :description "Common JDBC helpers for use in Puppet Labs projects"
   :url "https://github.com/puppetlabs/jdbc-util"
 
@@ -11,7 +11,7 @@
                  [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql]
                  [migratus "1.3.5" :exclusions [org.clojure/clojure]]
-                 [com.zaxxer/HikariCP]
+                 [com.zaxxer/HikariCP "5.0.1"]
                  [puppetlabs/kitchensink]
                  [puppetlabs/i18n]
                  [io.dropwizard.metrics/metrics-core]
@@ -31,7 +31,7 @@
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.9.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.3.0"]
                    :inherit [:managed-dependencies]}
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"

--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -114,8 +114,6 @@
   ([^HikariDataSource datasource init-fn timeout]
    (wrap-with-delayed-init datasource nil init-fn timeout))
   ([^HikariDataSource datasource migration-opts init-fn timeout]
-   (when-not (.getHealthCheckRegistry datasource)
-     (.setHealthCheckRegistry datasource (HealthCheckRegistry.)))
    (let [init-error (atom nil)
          init-exited-safely (promise)
          pool-future
@@ -245,4 +243,6 @@
    (connection-pool-with-delayed-init config nil init-fn timeout))
   ([^HikariConfig config migration-options init-fn timeout]
    (.setInitializationFailTimeout config -1)
+   (when-not (.getHealthCheckRegistry config)
+     (.setHealthCheckRegistry config (HealthCheckRegistry.)))
    (wrap-with-delayed-init (HikariDataSource. config) migration-options init-fn timeout)))


### PR DESCRIPTION
setHealthCheckRegistry can no longer be set after HikariDataSource has been instantiated in HikariCP 5.x. Adds setting in the HikariConfig beforehand.