### PR TITLE
(maint) fix logging message

### DIFF
--- a/src/puppetlabs/jdbc_util/pool.clj
+++ b/src/puppetlabs/jdbc_util/pool.clj
@@ -146,8 +146,8 @@
                         (log/debug (trs "{0} - Finished database migration" (.getPoolName datasource)))
                         datasource
                         (catch SQLTransientException e
-                               (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying.")
-                                   (.getPoolName datasource))
+                               (log/warnf e (trs "{0} - Error while attempting to connect to database, retrying."
+                                   (.getPoolName datasource)))
                                nil)
                         (catch Exception e
                           (reset! init-error e)


### PR DESCRIPTION
The database pool was on the wrong side of the parens and was being excluded from the logging information.  This fixes the issue so the database pool is correctly specified in the logging message.