### PR TITLE
(PE-37972) update clj-parent for pgjdbc v42.4.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,9 +18,8 @@
                  [io.dropwizard.metrics/metrics-healthchecks "3.2.2"]
                  [cheshire]]
 
-  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api "1.7.25"]
-                                  [org.slf4j/slf4j-log4j12 "1.7.25"]
-                                  [log4j/log4j "1.2.17"]]}}
+  :profiles {:dev {:dependencies [[org.slf4j/slf4j-api]
+                                  [org.slf4j/log4j-over-slf4j]]}}
 
   :plugins [[lein-release "1.0.9"]
             [lein-parent "0.3.7"]
@@ -31,7 +30,7 @@
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}
 
-  :parent-project {:coords [puppetlabs/clj-parent "5.3.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.6.15"]
                    :inherit [:managed-dependencies]}
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
This commit updates clj-parent to 5.6.15 to update pgjdbc to version 42.4.5. While the vulnerable version was not shipped, it triggered scan warnings in all the projects that included jdbc-util.

Also:
- remove the unneeded dependency on log4j/log4j
- remove the version pins on log4j-over-slf4j and org.slf4j/slf4j-api to take up the versions in clj-parent