### PR TITLE
(PE-37271) Swap postgres96 for pg14 in gh workflow

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:9.6.24
+        image: postgres:14
         env:
           POSTGRES_PASSWORD: foobar
         options: >-


### PR DESCRIPTION
The fixture for pg96 is soon to be retired, so this commit updates the github workflow to use pg14.