### PR TITLE
(maint) Update clojure/test.check to match other projects

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -4,10 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: main
-    paths: ['src/**','test/**']
   pull_request:
     types: [opened, reopened, edited, synchronize]
-    paths: ['src/**','test/**']
 
 env:
   JDBCUTIL_DBNAME: //127.0.0.1:5432/jdbc_util_test

--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14
+        image: postgres:14.6
         env:
           POSTGRES_PASSWORD: foobar
         options: >-

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
   :pedantic? :abort
   :dependencies [[org.clojure/clojure]
                  [org.clojure/java.jdbc]
-                 [org.clojure/test.check "0.9.0"]
                  [org.postgresql/postgresql]
                  [migratus "1.3.5" :exclusions [org.clojure/clojure]]
                  [com.zaxxer/HikariCP]
@@ -19,7 +18,8 @@
                  [cheshire]]
 
   :profiles {:dev {:dependencies [[org.slf4j/slf4j-api]
-                                  [org.slf4j/log4j-over-slf4j]]}}
+                                  [org.slf4j/log4j-over-slf4j]]}
+             :test {:dependencies [[org.clojure/test.check "1.1.1"]]}}
 
   :plugins [[lein-release "1.0.9"]
             [lein-parent "0.3.7"]


### PR DESCRIPTION
Jar-jar and puppetdb now use version 1.1.1 of `clojure.test/check`, so this library's pin to 0.9.0 causes dependency confusion in projects that depend on this and either of those. This commit updates the version used here to match the rest of the PE ecosystem.